### PR TITLE
Make get_camera_parameters use the same message as the app

### DIFF
--- a/tcp_protocol.json
+++ b/tcp_protocol.json
@@ -218,7 +218,8 @@
                 "returned_fields": [
                     {
                         "field_name": "parameter",
-                        "dtype": "<u1"
+                        "dtype": "<u1",
+                        "description": "a char describing what camera parameters were returned, 'a' for all parameters"
                     },
                     {
                         "field_name": "camera_bitrate",
@@ -483,7 +484,8 @@
                 "returned_fields": [
                     {
                         "field_name": "parameter",
-                        "dtype": "<u1"
+                        "dtype": "<u1",
+                        "description": "a char describing what camera parameters were returned, 'a' for all parameters"
                     },
                     {
                         "field_name": "camera_bitrate",


### PR DESCRIPTION
Node telecommunication ignores the second char, so any char can be
used. But if this is fixed in node_telecommunication it is better for the protocol to
be consistent with the app, so that only one place has to be changed. The app sends a "Va", "V" for get camera parameters, and "a" for all. 