### PR TITLE
Add 's' command for still pictures

### DIFF
--- a/tcp_protocol.json
+++ b/tcp_protocol.json
@@ -418,6 +418,11 @@
                 ]
             },
             {
+                "name": "take_still_picture",
+                "command_type": "s",
+                "description": "Takes a still picture and stores it locally on the drone."
+            },
+            {
                 "name": "set_camera_exposure",
                 "command_type": "ve",
                 "expected_reply": "a",


### PR DESCRIPTION
This feature was introduced in 1.4.7 but the protocol was not updated to reflect the change. 