### PR TITLE
Add command for setting gripper velocities

### DIFF
--- a/tcp_protocol.json
+++ b/tcp_protocol.json
@@ -834,6 +834,26 @@
                         "dtype": "<i4"
                     }
                 ]
+            },
+            {
+                "name": "set_gripper_velocities",
+                "command_type": "G",
+                "fields": [
+                    {
+                        "field_name": "gripping_velocity",
+                        "dtype": "<f4",
+                        "description": "The opening/closing velocity of the gripper. Postive values for open, negative for closing",
+                        "upper_limit": 1,
+                        "lower_limit": -1
+                    },
+                    {
+                        "field_name": "rotational_velocity",
+                        "dtype": "<f4",
+                        "description": "The rotational velocity of the gripper. Positive values for clockwise, negative for counter-clockwise",
+                        "upper_limit": 1,
+                        "lower_limit": -1
+                    }
+                ]
             }
         ]
     }

--- a/tcp_protocol.json
+++ b/tcp_protocol.json
@@ -842,7 +842,7 @@
                     {
                         "field_name": "gripping_velocity",
                         "dtype": "<f4",
-                        "description": "The opening/closing velocity of the gripper. Postive values for open, negative for closing",
+                        "description": "The opening/closing velocity of the gripper. Positive values for opening, negative for closing",
                         "upper_limit": 1,
                         "lower_limit": -1
                     },


### PR DESCRIPTION
Went with only gripping and rotational velocity for now, since most grippers support setting the angle directly I think that feature should be added in the future, but it's probably not necessary before we move over to the new protocol.