### PR TITLE
Add altitude message

### DIFF
--- a/protobuf_definitions/telemetry.proto
+++ b/protobuf_definitions/telemetry.proto
@@ -129,3 +129,11 @@ message ControlInputReference {
   float heave = 3;
   float yaw = 4;
 }
+
+/**
+ * Drone altitude over seabed, typically obtained from a DVL
+ */
+message Altitude {
+  int32 altitude = 1; // Drone altitude over seabed in mm
+  bool valid = 2; // Altitude valid or not
+}


### PR DESCRIPTION
The altitude is expressed in mm because Jonas wanted the
altitude information using the same unit as the depth data in the
udp protocol where mm is used.

The altitude message is meant for data obtained from a DVL but because
altitude is a generic telemetry value it is put in the telemetry.proto file