### PR TITLE
Rework nr of spectators

### DIFF
--- a/protobuf_definitions/message_formats.proto
+++ b/protobuf_definitions/message_formats.proto
@@ -362,6 +362,15 @@ message IperfStatus {
 /**
  * Number of spectators connected to video stream.
  */
+message NStreamers {
+  int32 main = 1; // The number of clients to the main camera stream
+  int32 guestport = 2; // The number of clients to the guestport camera stream
+}
+
+// TODO: deprecate
+/**
+ * Number of spectators connected to video stream.
+ */
 message Spectators {
   int32 value = 1; // The number of connected spectators
 }

--- a/protobuf_definitions/telemetry.proto
+++ b/protobuf_definitions/telemetry.proto
@@ -81,6 +81,11 @@ message IperfTel {
   IperfStatus status = 1;
 }
 
+message NStreamersTel {
+  NStreamers n_streamers = 1;
+}
+
+// TODO: deprecate
 message SpectatorsTel {
   Spectators spectators = 1;
 }


### PR DESCRIPTION
Use NStreamersTel instead of SpectatorsTel, to emphasize that it is the total number of streaming clients.

And include number of guestport streamers in the same message.

The old message is kept for backwards compability until we make larger changes in the protocol.