### PR TITLE
Add message type 3 for Cygnus Thickness Gauge

### DIFF
--- a/udp_protocol.json
+++ b/udp_protocol.json
@@ -872,6 +872,44 @@
                         "unit": ""
                     }
                 ]
+            },
+            {
+                "name": "cygnus",
+                "message_type": "3",
+                "fields":[
+                    {
+                        "description": "Protocol version",
+                        "dtype": "<u1",
+                        "field_name": "version",
+                        "unit": "",
+                        "init": "2"
+                    },
+                    {
+                        "description": "Command type",
+                        "dtype": "<u1",
+                        "field_name": "command_type",
+                        "unit": "",
+                        "init": "3"
+                    },
+                    {
+                        "description": "Thickness",
+                        "dtype": "<i2",
+                        "field_name": "thickness",
+                        "unit": "mm"
+                    },
+                    {
+                        "description": "EchoCount",
+                        "dtype": "<i1",
+                        "field_name": "echocount",
+                        "unit": ""
+                    },
+                    {
+                        "description": "Velocity",
+                        "dtype": "<i2",
+                        "field_name": "velocity",
+                        "unit": "m/s"
+                    }
+                ]
             }
         ]
     }

--- a/udp_protocol.json
+++ b/udp_protocol.json
@@ -893,9 +893,9 @@
                     },
                     {
                         "description": "Thickness",
-                        "dtype": "<i2",
+                        "dtype": "<f8",
                         "field_name": "thickness",
-                        "unit": "100mm"
+                        "unit": "mm"
                     },
                     {
                         "description": "EchoCount",

--- a/udp_protocol.json
+++ b/udp_protocol.json
@@ -895,7 +895,7 @@
                         "description": "Thickness",
                         "dtype": "<f8",
                         "field_name": "thickness",
-                        "unit": "mm"
+                        "unit": "m"
                     },
                     {
                         "description": "EchoCount",

--- a/udp_protocol.json
+++ b/udp_protocol.json
@@ -899,7 +899,7 @@
                     },
                     {
                         "description": "EchoCount",
-                        "dtype": "<i1",
+                        "dtype": "<u1",
                         "field_name": "echocount",
                         "unit": ""
                     },

--- a/udp_protocol.json
+++ b/udp_protocol.json
@@ -895,7 +895,7 @@
                         "description": "Thickness",
                         "dtype": "<i2",
                         "field_name": "thickness",
-                        "unit": "mm"
+                        "unit": "100mm"
                     },
                     {
                         "description": "EchoCount",


### PR DESCRIPTION
Add a new message type 3 for defining data coming from the Cygnus Thickness Gauge. The message contains Protocol version, Command type, Thickness, EchoCount and Velocity.