### PR TITLE
Build and install python modules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ install(TARGETS blueyeprotocol
 install(FILES ${ProtoHeaders} DESTINATION include/blueyeprotocol)
 
 add_custom_target(pyblueyeprotocol 
-                  DEPENDS ${PROTO_PYS})
+                  DEPENDS ${PROTO_PYS} blueyeprotocol)
 
 install(FILES ${PROTO_PYS} DESTINATION ${Python3_SITELIB} OPTIONAL)
 add_custom_target(python_bindings)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,10 +6,17 @@ include(GNUInstallDirs)
 
 
 find_package(Protobuf REQUIRED)
+find_package(Python3 COMPONENTS Interpreter REQUIRED)
+
+if(DEFINED ENV{VIRTUAL_ENV} OR DEFINED ENV{CONDA_PREFIX})
+  set(_pip_args)
+else()
+  set(_pip_args "--user")
+endif()
 
 file(GLOB ProtoFiles "protobuf_definitions/*.proto")
 PROTOBUF_GENERATE_CPP(ProtoSources ProtoHeaders ${ProtoFiles})
-protobuf_generate_python(PROTO_PY ${ProtoFiles})
+protobuf_generate_python(PROTO_PYS ${ProtoFiles})
 
 add_library(blueyeprotocol SHARED ${ProtoSources} ${ProtoHeaders})
 
@@ -21,6 +28,10 @@ install(TARGETS blueyeprotocol
         LIBRARY DESTINATION lib)
 install(FILES ${ProtoHeaders} DESTINATION include/blueyeprotocol)
 
+add_custom_target(pyblueyeprotocol ALL
+                  DEPENDS ${PROTO_PYS})
+
+install(FILES ${PROTO_PYS} DESTINATION ${Python3_SITELIB})
 
 # ---------------------------------------------------------------------------------------
 # Install cmake config
@@ -40,4 +51,4 @@ write_basic_package_version_file(
   COMPATIBILITY SameMajorVersion )
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/blueyeprotocolConfig.cmake
               ${CMAKE_CURRENT_BINARY_DIR}/blueyeprotocolConfigVersion.cmake
-        DESTINATION ${LIB_INSTALL_DIR}/cmake/blueyeprotocol )
+        DESTINATION ${LIB_INSTALL_DIR}/cmake/blueyeprotocol)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,12 +8,6 @@ include(GNUInstallDirs)
 find_package(Protobuf REQUIRED)
 find_package(Python3 COMPONENTS Interpreter REQUIRED)
 
-if(DEFINED ENV{VIRTUAL_ENV} OR DEFINED ENV{CONDA_PREFIX})
-  set(_pip_args)
-else()
-  set(_pip_args "--user")
-endif()
-
 file(GLOB ProtoFiles "protobuf_definitions/*.proto")
 PROTOBUF_GENERATE_CPP(ProtoSources ProtoHeaders ${ProtoFiles})
 protobuf_generate_python(PROTO_PYS ${ProtoFiles})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,10 +22,12 @@ install(TARGETS blueyeprotocol
         LIBRARY DESTINATION lib)
 install(FILES ${ProtoHeaders} DESTINATION include/blueyeprotocol)
 
-add_custom_target(pyblueyeprotocol ALL
+add_custom_target(pyblueyeprotocol 
                   DEPENDS ${PROTO_PYS})
 
-install(FILES ${PROTO_PYS} DESTINATION ${Python3_SITELIB})
+install(FILES ${PROTO_PYS} DESTINATION ${Python3_SITELIB} OPTIONAL)
+add_custom_target(python_bindings)
+add_dependencies(python_bindings pyblueyeprotocol)
 
 # ---------------------------------------------------------------------------------------
 # Install cmake config


### PR DESCRIPTION
Not yet completely happy that it installs directly to site directory. Would be nice to have it in a common module blueyeprotocol/blueye.protocol bur I didn't manage to generate a meaningful module structure with the files provided by Protobuf. They import each other by name and therefore need to be in global name space.