### PR TITLE
Add auto altitude control mode

### DIFF
--- a/protobuf_definitions/control.proto
+++ b/protobuf_definitions/control.proto
@@ -61,6 +61,10 @@ message AutoDepthCtrl {
   AutoDepthState state = 1;
 }
 
+message AutoAltitudeCtrl {
+  AutoAltitudeState state = 1;
+} 
+
 message TiltStabilizationCtrl {
   TiltStabilizationState state = 1;
 }

--- a/protobuf_definitions/control.proto
+++ b/protobuf_definitions/control.proto
@@ -53,16 +53,25 @@ message CancelCalibrationCtrl {
 message FinishCalibrationCtrl {
 }
 
+/**
+  * Issue a command to set auto heading to a desired state.
+  */
 message AutoHeadingCtrl {
-  AutoHeadingState state = 1;
+  AutoHeadingState state = 1; // State of the heading controller
 }
 
+/**
+  * Issue a command to set auto depth to a desired state.
+  */
 message AutoDepthCtrl {
-  AutoDepthState state = 1;
+  AutoDepthState state = 1; // State of the depth controller
 }
 
+/**
+  * Issue a command to set auto altitude to a desired state.
+  */
 message AutoAltitudeCtrl {
-  AutoAltitudeState state = 1;
+  AutoAltitudeState state = 1; // State of the altitude controller
 } 
 
 message TiltStabilizationCtrl {

--- a/protobuf_definitions/message_formats.proto
+++ b/protobuf_definitions/message_formats.proto
@@ -85,6 +85,13 @@ message AutoDepthState {
 }
 
 /**
+  * Auto altitude state.
+  */
+message AutoAltitudeState {
+  bool enabled = 1; // If auto depth is enabled
+}
+
+/**
   * Tilt stabilization state.
   *
   * Blueye drones with mechanical tilt has the ability to enable

--- a/protobuf_definitions/message_formats.proto
+++ b/protobuf_definitions/message_formats.proto
@@ -88,7 +88,7 @@ message AutoDepthState {
   * Auto altitude state.
   */
 message AutoAltitudeState {
-  bool enabled = 1; // If auto depth is enabled
+  bool enabled = 1; // If auto altitude is enabled
 }
 
 /**

--- a/protobuf_definitions/telemetry.proto
+++ b/protobuf_definitions/telemetry.proto
@@ -105,3 +105,24 @@ message DroneInfoTel {
 message ErrorFlagsTel {
   ErrorFlags error_flags = 1;
 }
+
+/**
+  * Receive the current state of the auto heading controller.
+  */
+message AutoHeadingTel {
+  AutoHeadingState state = 1; // State of the heading controller
+}
+
+/**
+  * Receive the current state of the auto depth controller.
+  */
+message AutoDepthTel {
+  AutoDepthState state = 1; // State of the depth controller
+}
+
+/**
+  * Receive the current state of the auto altitude controller.
+  */
+message AutoAltitudeTel {
+  AutoAltitudeState state = 1; // State of the altitude controller
+} 


### PR DESCRIPTION
This PR adds new control mode, auto altitude to the protocol. It also adds all controller states to the telemetry stream that were missing.