### PR TITLE
Publish all control modes as one tel message

### DIFF
--- a/protobuf_definitions/message_formats.proto
+++ b/protobuf_definitions/message_formats.proto
@@ -303,18 +303,13 @@ message Depth {
 }
 
 message Reference {
-  float surge = 1;
-  float sway = 2;
-  float heave = 3;
-  float yaw = 4;
+  float surge = 1; // Reference from joystick surge input
+  float sway = 2; // Reference from joystick sway input
+  float heave = 3; // Reference from joystick heave input
+  float yaw = 4; // Reference from joystick yaw input
   float depth = 5; // Reference drone depth below surface in m
-
-// Can be added as needed:
-  //float depth_rate = 6;
-  //float depth_acc = 7;
-  //float heading = 8;
-  //float heading_rate = 9;
-  //float heading_acc = 10;
+  float heading = 6; // Reference used in auto heading mode
+  float altitude = 7; // Reference used in auto altitude mode
 }
 
 /**

--- a/protobuf_definitions/message_formats.proto
+++ b/protobuf_definitions/message_formats.proto
@@ -92,6 +92,18 @@ message AutoAltitudeState {
 }
 
 /**
+  * Control mode from drone supervisor
+  */
+message ControlMode {
+  bool auto_depth = 1; // If auto depth is enabled
+  bool auto_heading = 2; // If auto heading is enabled
+  bool auto_altitude = 3; // If auto altitude is enabled
+  // bool auto_station_keeping = 4; // Not implemented yet
+  // bool auto_surge_distance = 5; // Not implemented yet
+  // bool auto_path_following = 6; // Not implemented yet
+}
+
+/**
   * Tilt stabilization state.
   *
   * Blueye drones with mechanical tilt has the ability to enable

--- a/protobuf_definitions/telemetry.proto
+++ b/protobuf_definitions/telemetry.proto
@@ -107,22 +107,8 @@ message ErrorFlagsTel {
 }
 
 /**
-  * Receive the current state of the auto heading controller.
+  * Receive the current state of the control system.
   */
-message AutoHeadingTel {
-  AutoHeadingState state = 1; // State of the heading controller
+message CotrolModeTel {
+  ControlMode state = 1; // State of the control system.
 }
-
-/**
-  * Receive the current state of the auto depth controller.
-  */
-message AutoDepthTel {
-  AutoDepthState state = 1; // State of the depth controller
-}
-
-/**
-  * Receive the current state of the auto altitude controller.
-  */
-message AutoAltitudeTel {
-  AutoAltitudeState state = 1; // State of the altitude controller
-} 


### PR DESCRIPTION
It turns out it is better to publish the state of all the control modes as one message. This also fits better with comm in p2_drone.

