### PR TITLE
Change CMake include dir

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ add_dependencies(python_bindings pyblueyeprotocol)
 # Install cmake config
 # ---------------------------------------------------------------------------------------
 
-set(INCLUDE_INSTALL_DIR include/blueyeprotocol )
+set(INCLUDE_INSTALL_DIR include )
 set(LIB_INSTALL_DIR lib/)
 
 include(CMakePackageConfigHelpers)


### PR DESCRIPTION
We use `#include "blueyeprotocol/<...>.pb.h"` in our code, so the directory to be included should not be `include/blueyeprotocol`, but `include`. This leads to code not compiling when the `include` folder isn't set by coincidence by another library.