### PR TITLE
Add ForwardDistance to message and telemetry

### DIFF
--- a/protobuf_definitions/message_formats.proto
+++ b/protobuf_definitions/message_formats.proto
@@ -292,7 +292,16 @@ message Attitude {
  */
 message Altitude {
   float value = 1; // Drone altitude over seabed in m
-  bool valid = 2; // Altitude valid or not
+  bool valid = 2; // If altitude is valid or not
+}
+
+/**
+ * Distance to an object infront of the drone, typically obtained from an 1D
+ * pinger.
+ */
+message ForwardDistance {
+  float value = 1; // Distance in front of drone in m
+  bool valid = 2; // If distance reading is valid or not
 }
 
 /**

--- a/protobuf_definitions/telemetry.proto
+++ b/protobuf_definitions/telemetry.proto
@@ -17,6 +17,10 @@ message AltitudeTel {
   Altitude altitude = 1;
 }
 
+message ForwardDistanceTel {
+  ForwardDistance forward_distance = 1;
+}
+
 message DepthTel {
   Depth depth = 1;
 }


### PR DESCRIPTION
If the BR pinger is mounted forwards this message is used to display the distance in the app.