### PR TITLE
Publish NuGet package

### DIFF
--- a/.github/workflows/ci-dotnet.yaml
+++ b/.github/workflows/ci-dotnet.yaml
@@ -25,4 +25,6 @@ jobs:
           dotnet pack Blueye.Protocol.Protobuf.csproj --version-suffix "ci.$GITHUB_RUN_NUMBER" -c Release -o out  
 
       - name: Push generated package to GitHub registry
+        env:
+          NUGET_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}      
         run: dotnet nuget push ./out/*.nupkg --skip-duplicate --no-symbols true --api-key $NUGET_AUTH_TOKEN

--- a/.github/workflows/ci-dotnet.yaml
+++ b/.github/workflows/ci-dotnet.yaml
@@ -7,7 +7,7 @@ on:
       - nuget-package
 
 jobs:
-  protolint:
+  donet-ci-build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source
@@ -25,4 +25,4 @@ jobs:
           dotnet pack Blueye.Protocol.Protobuf.csproj --version-suffix "ci.$GITHUB_RUN_NUMBER" -c Release -o out  
 
       - name: Push generated package to GitHub registry
-        run: dotnet nuget push ./out/*.nupkg --skip-duplicate --no-symbols true
+        run: dotnet nuget push ./out/*.nupkg --skip-duplicate --no-symbols true --api-key $NUGET_AUTH_TOKEN

--- a/.github/workflows/ci-dotnet.yaml
+++ b/.github/workflows/ci-dotnet.yaml
@@ -1,0 +1,27 @@
+name: CI build
+
+on:
+  push:
+    branches:
+      - port-protocol-to-protobuf
+
+jobs:
+  protolint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v1
+
+      - name: Setup .NET Core @ Latest
+        uses: actions/setup-dotnet@v1
+        with:
+          source-url: https://nuget.pkg.github.com/BluEye-Robotics/index.json
+        env:
+          NUGET_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
+      - name: Build project and generate NuGet package
+        run: |          
+          dotnet pack Blueye.Protocol.Protobuf.csproj --version-suffix "ci.$GITHUB_RUN_NUMBER" -c Release -o out  
+
+      - name: Push generated package to GitHub registry
+        run: dotnet nuget push ./out/*.nupkg --skip-duplicate --no-symbols true

--- a/.github/workflows/ci-dotnet.yaml
+++ b/.github/workflows/ci-dotnet.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - port-protocol-to-protobuf
+      - nuget-package
 
 jobs:
   protolint:

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,11 @@ docs
 lib*.so
 *.o
 
+# dotnet outputs
+bin
+obj
+out
+
 # Other
 build
 build_imx

--- a/Blueye.Protocol.Protobuf.csproj
+++ b/Blueye.Protocol.Protobuf.csproj
@@ -8,7 +8,7 @@
     <Company>Blueye Robotics AS</Company>
     <ProduceReferenceAssembly>True</ProduceReferenceAssembly>
     <PackageDescription>Library with dotnet representation of the ProtocolDefinition protobuf files.</PackageDescription>
-    <RepositoryUrl>https://github.com/BluEye-Robotics/BlueyeApp</RepositoryUrl>
+    <RepositoryUrl>https://github.com/BluEye-Robotics/ProtocolDefinitions</RepositoryUrl>
   </PropertyGroup>
   
   <ItemGroup>

--- a/Blueye.Protocol.Protobuf.csproj
+++ b/Blueye.Protocol.Protobuf.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <LangVersion>8.0</LangVersion>
+    <PackageId>Blueye.Protocol.Protobuf</PackageId>
+    <VersionPrefix>0.0.1</VersionPrefix>
+    <Company>Blueye Robotics AS</Company>
+    <ProduceReferenceAssembly>True</ProduceReferenceAssembly>
+    <PackageDescription>Library with dotnet representation of the ProtocolDefinition protobuf files.</PackageDescription>
+    <RepositoryUrl>https://github.com/BluEye-Robotics/BlueyeApp</RepositoryUrl>
+  </PropertyGroup>
+  
+  <ItemGroup>
+    <PackageReference Include="Google.Protobuf" Version="3.19.1" />
+    <PackageReference Include="Google.Protobuf.Tools" Version="3.19.1">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Grpc.Tools" Version="2.41.1">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Protobuf Include="**/*.proto" ProtoRoot="protobuf_definitions" GrpcServices="None" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
This pull request move the `Blueye.Protocol.Protobuf.csproj` file from the BlueyeApp repository to the ProtocolDefinitions repository, as well as adding a GitHub Action workflow to publish the library as a NuGet package on every build (with a `-ci.NUMBER` suffix).

When we are ready to make the first official release, I will have to add an additional workflow that uses GitHub release tags to trigger the non-preview builds of the package.