### PR TITLE
Add thickness gauge message to protobuf

### DIFF
--- a/protobuf_definitions/message_formats.proto
+++ b/protobuf_definitions/message_formats.proto
@@ -703,8 +703,8 @@ message GuestPortInfo {
  * Thickness measurement data from a Cygnus Thickness Gauge
  */
 message ThicknessGauge {
-  float thickness_measurement; // Thickness measurement of a steel plate
-  uint32 echo_count; // Number of echoes recieved, indicating the quality of the reading when the reading is invalid. Range [0-3]
-  int32 sound_velocity; // Speed of sound in the steel member
-  bool valid_measurement; // Indicating if the measurement is valid
+  float thickness_measurement = 1; // Thickness measurement of a steel plate
+  uint32 echo_count = 2; // Number of echoes recieved, indicating the quality of the reading when the reading is invalid. Range [0-3]
+  int32 sound_velocity = 3; // Speed of sound in the steel member
+  bool valid_measurement = 4; // Indicating if the measurement is valid
 }

--- a/protobuf_definitions/message_formats.proto
+++ b/protobuf_definitions/message_formats.proto
@@ -705,6 +705,6 @@ message GuestPortInfo {
 message ThicknessGauge {
   float thickness_measurement = 1; // Thickness measurement of a steel plate
   uint32 echo_count = 2; // Number of echoes recieved, indicating the quality of the reading when the reading is invalid. Range [0-3]
-  int32 sound_velocity = 3; // Speed of sound in the steel member
+  uint32 sound_velocity = 3; // Speed of sound in the steel member
   bool valid_measurement = 4; // Indicating if the measurement is valid
 }

--- a/protobuf_definitions/message_formats.proto
+++ b/protobuf_definitions/message_formats.proto
@@ -704,7 +704,7 @@ message GuestPortInfo {
  */
 message ThicknessGauge {
   float thickness_measurement = 1; // Thickness measurement of a steel plate
-  uint32 echo_count = 2; // Number of echoes recieved, indicating the quality of the reading when the reading is invalid. Range [0-3]
+  uint32 echo_count = 2; // Indicating the quality of the reading when invalid (0-3).
   uint32 sound_velocity = 3; // Speed of sound in the steel member
   bool valid_measurement = 4; // Indicating if the measurement is valid
 }

--- a/protobuf_definitions/message_formats.proto
+++ b/protobuf_definitions/message_formats.proto
@@ -698,3 +698,13 @@ message GuestPortInfo {
   GuestPortConnectorInfo gp2 = 2; // GuestPortConnectorInfo 2
   GuestPortConnectorInfo gp3 = 3; // GuestPortConnectorInfo 3
 }
+
+/**
+ * Thickness measurement data from a Cygnus Thickness Gauge
+ */
+message ThicknessGauge {
+  float thickness_measurement; // Thickness measurement of a steel plate
+  uint32 echo_count; // Number of echoes recieved, indicating the quality of the reading when the reading is invalid. Range [0-3]
+  int32 sound_velocity; // Speed of sound in the steel member
+  bool valid_measurement; // Indicating if the measurement is valid
+}

--- a/protobuf_definitions/telemetry.proto
+++ b/protobuf_definitions/telemetry.proto
@@ -122,5 +122,5 @@ message ControlModeTel {
 }
 
 message ThicknessGaugeTel {
-  ThicknessGauge state = 1;  // Tickness 
+  ThicknessGauge thickness_gauge = 1;  // Tickness measurement with a cygnus gauge
 }

--- a/protobuf_definitions/telemetry.proto
+++ b/protobuf_definitions/telemetry.proto
@@ -120,3 +120,7 @@ message ErrorFlagsTel {
 message ControlModeTel {
   ControlMode state = 1;  // State of the control system.
 }
+
+message ThicknessGaugeTel {
+  ThicknessGauge state = 1;  // Tickness 
+}


### PR DESCRIPTION
Adding new message for the thickness gauge. The set material sound velocity service was already implemented. 