### PR TITLE
Use double for lat long positions

### DIFF
--- a/protobuf_definitions/message_formats.proto
+++ b/protobuf_definitions/message_formats.proto
@@ -51,8 +51,8 @@ message Lights {
   * Latitude and longitude position in WGS 84 format.
   */
 message LatLongPosition {
-  float latitude = 1; // Latitude
-  float longitude = 2; // Longitude
+  double latitude = 1; // Latitude
+  double longitude = 2; // Longitude
 }
 
 /**


### PR DESCRIPTION
Turns out that float was not sufficient accuracy for lat long positions.