### PR TITLE
Bump major version for python package

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,7 @@ Version 3 of the Blueye communication protocol is based on [Protocol Buffers](ht
 
 The protobuf definitions are compiled to language specific libraries, and are available as a [NuGet package](https://github.com/BluEye-Robotics/ProtocolDefinitions/packages/1239508) and a [Python package](https://pypi.org/project/blueye.protocol/).
 
-Automatically generated documentation for the protocol format can be found at https://blueyebuildserver.blob.core.windows.net/protocoldefinitions/docs/protocol.html.
-
-This documentation will be merged with the `blueye.sdk` repository when v3 is finalized.
+Automatically generated documentation for the protocol format can be found [here](https://blueyebuildserver.blob.core.windows.net/protocoldefinitions/docs/protocol.html).
 
 ### Installation
 #### OS X

--- a/README.md
+++ b/README.md
@@ -2,15 +2,15 @@
 
 [![CI build](https://github.com/BluEye-Robotics/ProtocolDefinitions/actions/workflows/ci-build.yaml/badge.svg)](https://github.com/BluEye-Robotics/ProtocolDefinitions/actions/workflows/ci-build.yaml)
 
-This repository contains protocol definitions for interacting with the Blueye Pioneer and Blueye Pro underwater drone.
+This repository contains protocol definitions for interacting with the Blueye underwater drones.
 
 ## Protocol v2
-See [blueye.protocol](https://github.com/BluEye-Robotics/blueye.protocol) and
-[blueye.sdk](https://github.com/BluEye-Robotics/blueye.sdk) for Python libraries that
-are built on these definitions and simplifies their use.
+Drones running a Blunux version \< 3.0 will need to use the legacy protocol. [blueye.legacyprotocol](https://github.com/BluEye-Robotics/blueye.legacyprotocol) contains a Python package that is built on this protocol and simplifies its use.
 
 ## Protocol v3
 Version 3 of the Blueye communication protocol is based on [Protocol Buffers](https://developers.google.com/protocol-buffers).
+
+The protobuf definitions are compiled to language specific libraries, and are available as a [NuGet package](https://github.com/BluEye-Robotics/ProtocolDefinitions/packages/1239508) and a [Python package](https://pypi.org/project/blueye.protocol/).
 
 Automatically generated documentation for the protocol format can be found at https://blueyebuildserver.blob.core.windows.net/protocoldefinitions/docs/protocol.html.
 

--- a/python_build/README.md
+++ b/python_build/README.md
@@ -1,0 +1,8 @@
+# blueye.protocol
+
+`blueye.protocol` is a python package generated from the Protobuf API defined in [ProtocolDefintions](https://github.com/BluEye-Robotics/ProtocolDefinitions).
+
+It is generated with the [proto-plus library](https://proto-plus-python.readthedocs.io/en/latest/) create a more Pythonic way to interact with protocol buffers.
+
+## Usage
+The primary user of this package is the [blueye.sdk](https://github.com/blueye-robotics/blueye.sdk). The SDK configures the necessary ZeroMQ sockets and wraps everything up in an easy to use Python-object, allowing you to control the Blueye drones remotely.

--- a/python_build/pyproject.toml
+++ b/python_build/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "blueye.protocol"
-version = "2.0.0"
+version = "3.0.0"
 description = "Protobuf-based protocol definitions for the Blueye drones"
 authors = ["Sindre Hansen <sindre.hansen@blueye.no>"]
 license = "LGPL-3.0"
@@ -11,6 +11,10 @@ include = ["blueye/protocol/*",
 packages = [
   { include = "blueye" },
 ]
+readme = "README.md"
+repository="https://github.com/blueye-robotics/ProtocolDefinitions"
+homepage ="https://www.blueyerobotics.com"
+keywords = ["Blueye", "Robotics", "Protocol"]
 
 [tool.poetry.dependencies]
 python = "^3.7"


### PR DESCRIPTION
The major versions for the `blueye.protocol` python package will now be:
- 1.5: Old tcp/udp based, with the blueye.protocol name
- 2.0: Same protocol as 1.5, but renamed to blueye.legacyprotocol
- 3.0: New protobuf-based protocol, published to blueye.protocol package 