### PR TITLE
Add GetBatteryReq message

### DIFF
--- a/protobuf_definitions/req_rep.proto
+++ b/protobuf_definitions/req_rep.proto
@@ -144,3 +144,19 @@ message DisconnectClientRep {
   uint32 client_id_in_control = 1; // The ID of the client in control of the drone.
   repeated ConnectedClient connected_clients = 2; // List of connected clients.
 }
+
+/*
+ * Request essential battery information.
+ *
+ * Can be used to instantly get battery information,
+ * instead of having to wait for the BatteryTel message to be received.
+ */
+message GetBatteryReq {
+}
+
+/*
+ * Response with essential battery information.
+ */
+message GetBatteryRep {
+  Battery battery = 1; // Essential battery information.
+}

--- a/protobuf_definitions/telemetry.proto
+++ b/protobuf_definitions/telemetry.proto
@@ -59,12 +59,19 @@ message RecordStateTel {
   RecordState record_state = 1;
 }
 
+/*
+ * Receive essential information about the battery status.
+ */
 message BatteryTel {
-  Battery battery = 1;
+  Battery battery = 1; // Essential battery information.
 }
 
+/*
+ * Receive detailed information about a battery using the
+* BQ40Z50 battery management system.
+ */
 message BatteryBQ40Z50Tel {
-  BatteryBQ40Z50 battery = 1;
+  BatteryBQ40Z50 battery = 1; // Detailed battery information.
 }
 
 /*


### PR DESCRIPTION
The `BatteryTel` message is published at a low rate (~5s), giving the impression of the system being "slow" as the client has to wait several seconds before the drone battery percentage is displayed on the connect screen.

By adding a `GetBatteryReq` message, the client can request the battery level as part of the connection flow, ensuring the battery percentage is available instantly.