### PR TITLE
Add control force message to protocol

### DIFF
--- a/protobuf_definitions/message_formats.proto
+++ b/protobuf_definitions/message_formats.proto
@@ -383,6 +383,16 @@ message Reference {
 }
 
 /**
+ * Control Force is used for showing the requested control force in each direction in Newtons.
+ */
+message ControlForce {
+  float surge = 1; // Force in surge
+  float sway = 2; // Force in sway
+  float heave = 3; // Force in heave
+  float yaw = 4; // Moment in yaw
+}
+
+/**
  * Controller health is used for showing the state of the controller with an relative error and load from 0 to 1.
  */
 message ControllerHealth {

--- a/protobuf_definitions/telemetry.proto
+++ b/protobuf_definitions/telemetry.proto
@@ -39,6 +39,10 @@ message ReferenceTel {
   Reference reference = 1;
 }
 
+message ControlForceTel {
+  ControlForce control_force = 1;
+}
+
 message ControllerHealthTel {
   ControllerHealth controller_health = 1;
 }


### PR DESCRIPTION
Adds control force to the new protocol for later use with buoyancy trimming etc. Also for backwards compatibility in dive logs.