### PR TITLE
Add more current-related error flags

### DIFF
--- a/protobuf_definitions/message_formats.proto
+++ b/protobuf_definitions/message_formats.proto
@@ -578,6 +578,10 @@ message ErrorFlags {
   bool ds_serial = 36;  // DS serial number error
   bool gp_current_read = 37;  // Error reading GP current
   bool gp_current = 38;  // Max GP current exceeded
+  bool gp1_bat_current = 39;  // Max battery current exceeded on GP1
+  bool gp2_bat_current = 40;  // Max battery current exceeded on GP2
+  bool gp3_bat_current = 41;  // Max battery current exceeded on GP3
+  bool gp_20v_current = 42;  // Max 20V current exceeded on GP
 }
 
 /**


### PR DESCRIPTION
We can phase out flag 38 later, but didn't want to remove it yet, so we can read the log files in our tools.