### PR TITLE
Reset position settings

### DIFF
--- a/protobuf_definitions/control.proto
+++ b/protobuf_definitions/control.proto
@@ -125,6 +125,7 @@ message WeatherVaningCtrl {
   * Issue a command to reset the position estimate.
   */
 message ResetPositionCtrl {
+  ResetPositionSettings settings = 1; // Reset options.
 }
 
 /**

--- a/protobuf_definitions/control.proto
+++ b/protobuf_definitions/control.proto
@@ -125,7 +125,7 @@ message WeatherVaningCtrl {
   * Issue a command to reset the position estimate.
   */
 message ResetPositionCtrl {
-  ResetPositionSettings settings = 1; // Reset options.
+  ResetPositionSettings settings = 1; // Reset settings.
 }
 
 /**

--- a/protobuf_definitions/message_formats.proto
+++ b/protobuf_definitions/message_formats.proto
@@ -364,6 +364,22 @@ message PositionEstimate {
 }
 
 /**
+  * Heading source used during reset of the position estimate.
+  */
+enum HeadingSource {
+  HEADING_SOURCE_UNSPECIFIED = 0; // Unspecified
+  HEADING_SOURCE_DRONE_COMPASS = 1; // Uses the drone compass to set the heading
+  HEADING_SOURCE_DUE_NORTH = 2; // Used when the user orientes the drone due North manually
+}
+
+/**
+  * ResetPositionSettings used during reset of the position estimate.
+  */
+message ResetPositionSettings {
+  HeadingSource heading_source_during_reset = 1; // Option to use the drone compass or due North as heading during reset
+}
+
+/**
  * Water depth of the drone.
  */
 message Depth {


### PR DESCRIPTION
This PR adds the functionality to set "Point drone due North" or "Drone Compass" as heading source during reset.