### PR TITLE
Add messages for scaling lasers

### DIFF
--- a/protobuf_definitions/control.proto
+++ b/protobuf_definitions/control.proto
@@ -38,6 +38,13 @@ message GuestportLightsCtrl {
 }
 
 /**
+  * Issue a command to set the laser intensity.
+  */
+message LaserCtrl {
+  Lasers lasers = 1; // Message with the desired laser intensity.
+}
+
+/**
   * Issue a command with the GPS position of the pilot.
   */
 message PilotGPSPositionCtrl {

--- a/protobuf_definitions/control.proto
+++ b/protobuf_definitions/control.proto
@@ -41,7 +41,7 @@ message GuestportLightsCtrl {
   * Issue a command to set the laser intensity.
   */
 message LaserCtrl {
-  Lasers lasers = 1; // Message with the desired laser intensity.
+  Laser laser = 1; // Message with the desired laser intensity.
 }
 
 /**

--- a/protobuf_definitions/message_formats.proto
+++ b/protobuf_definitions/message_formats.proto
@@ -48,13 +48,13 @@ message Lights {
 }
 
 /**
-  * Lasers message used to represent the intensity of connected lasers.
+  * Laser message used to represent the intensity of connected laser.
   *
   * If the laser does not support dimming but only on and off,
   * a value of 0 turns the laser off, and any value above 0
   * turns the laser on.
   */
-message Lasers {
+message Laser {
   float value = 1; // Laser intensity, any value above 0 turns the laser on (0..1)
 }
 

--- a/protobuf_definitions/message_formats.proto
+++ b/protobuf_definitions/message_formats.proto
@@ -48,6 +48,17 @@ message Lights {
 }
 
 /**
+  * Lasers message used to represent the intensity of connected lasers.
+  *
+  * If the laser does not support dimming but only on and off,
+  * a value of 0 turns the laser off, and any value above 0
+  * turns the laser on.
+  */
+message Lasers {
+  float value = 1; // Laser intensity, any value above 0 turns the laser on (0..1)
+}
+
+/**
   * Latitude and longitude position in WGS 84 decimal degrees format.
   */
 message LatLongPosition {
@@ -756,6 +767,8 @@ enum GuestPortDeviceID {
   GUEST_PORT_DEVICE_ID_BLUE_ROBOTICS_DETACHABLE_NEWTON = 24; // Detachable Blue Robotics Newton
   GUEST_PORT_DEVICE_ID_INSITU_AQUA_TROLL_500 = 25; // In-Situ Aqua TROLL 500
   GUEST_PORT_DEVICE_ID_MEDUSA_RADIOMETRICS_MS_100 = 26; // Medusa Radiometrics Gamma Ray Sensor
+  GUEST_PORT_DEVICE_ID_LASER_TOOLS_SEA_BEAM = 27; // Laser Tools Sea Beam Underwater Laser
+  GUEST_PORT_DEVICE_ID_SPOT_X_LASER_SCALERS = 28; // Spot X Laser Scalers
 
 }
 

--- a/protobuf_definitions/telemetry.proto
+++ b/protobuf_definitions/telemetry.proto
@@ -47,12 +47,25 @@ message ControllerHealthTel {
   ControllerHealth controller_health = 1;
 }
 
+/**
+  * Receive the status of the main lights of the drone.
+  */
 message LightsTel {
   Lights lights = 1;
 }
 
+/**
+  * Receive the status of any guest port lights connected to the drone.
+  */
 message GuestPortLightsTel {
   Lights lights = 1;
+}
+
+/**
+  * Receive the status of any lasers connected to the drone.
+  */
+message LaserTel {
+  Lasers lasers = 1;
 }
 
 message PilotGPSPositionTel {
@@ -72,7 +85,7 @@ message BatteryTel {
 
 /*
  * Receive detailed information about a battery using the
-* BQ40Z50 battery management system.
+ * BQ40Z50 battery management system.
  */
 message BatteryBQ40Z50Tel {
   BatteryBQ40Z50 battery = 1; // Detailed battery information.

--- a/protobuf_definitions/telemetry.proto
+++ b/protobuf_definitions/telemetry.proto
@@ -65,7 +65,7 @@ message GuestPortLightsTel {
   * Receive the status of any lasers connected to the drone.
   */
 message LaserTel {
-  Lasers lasers = 1;
+  Laser lasers = 1;
 }
 
 message PilotGPSPositionTel {

--- a/protobuf_definitions/telemetry.proto
+++ b/protobuf_definitions/telemetry.proto
@@ -65,7 +65,7 @@ message GuestPortLightsTel {
   * Receive the status of any lasers connected to the drone.
   */
 message LaserTel {
-  Laser lasers = 1;
+  Laser laser = 1;
 }
 
 message PilotGPSPositionTel {


### PR DESCRIPTION
Adds guest port device IDs for Laser Tools and Spot X lasers. I did consider re-using the `Lights` message, which has a `float value` field. But, at the same time, there is marginal gain by reusing it, and we might want to add additional fields specific to the lasers, such as width between the dots, size of the dot, etc.