### PR TITLE
Add option to reset position to manual coordinate

### DIFF
--- a/protobuf_definitions/message_formats.proto
+++ b/protobuf_definitions/message_formats.proto
@@ -389,6 +389,14 @@ enum HeadingSource {
 message ResetPositionSettings {
   HeadingSource heading_source_during_reset = 1; // Option to use the drone compass or due North as heading during reset
   float manual_heading = 2; // Heading in degrees (0-359)
+  ResetCoordinateSource reset_coordinate_source = 3; // Option to use the device GPS or a manual coordinate.
+  optional LatLongPosition reset_coordinate = 4; // Reset coordinate in decimal degrees
+}
+
+enum ResetCoordinateSource {
+  RESET_COORDINATE_SOURCE_UNSPECIFIED = 0; // Unspecified, fallback to device GPS
+  RESET_COORDINATE_SOURCE_DEVICE_GPS = 1; // Uses the device GPS to set the reset point
+  RESET_COORDINATE_SOURCE_MANUAL = 2; // Uses a coordinate in decimal degrees to set the reset point
 }
 
 /**


### PR DESCRIPTION
To make it possible to reset the DVL position to a known POI instead of the device GPS.