### PR TITLE
Remove underscore in Medusa MS100 sensor name

### DIFF
--- a/protobuf_definitions/message_formats.proto
+++ b/protobuf_definitions/message_formats.proto
@@ -774,7 +774,7 @@ enum GuestPortDeviceID {
   GUEST_PORT_DEVICE_ID_BLUEYE_MULTIBEAM_SERVO = 23; // Blueye Multibeam Servo
   GUEST_PORT_DEVICE_ID_BLUE_ROBOTICS_DETACHABLE_NEWTON = 24; // Detachable Blue Robotics Newton
   GUEST_PORT_DEVICE_ID_INSITU_AQUA_TROLL_500 = 25; // In-Situ Aqua TROLL 500
-  GUEST_PORT_DEVICE_ID_MEDUSA_RADIOMETRICS_MS_100 = 26; // Medusa Radiometrics Gamma Ray Sensor
+  GUEST_PORT_DEVICE_ID_MEDUSA_RADIOMETRICS_MS100 = 26; // Medusa Radiometrics Gamma Ray Sensor
   GUEST_PORT_DEVICE_ID_LASER_TOOLS_SEA_BEAM = 27; // Laser Tools Sea Beam Underwater Laser
   GUEST_PORT_DEVICE_ID_SPOT_X_LASER_SCALERS = 28; // Spot X Laser Scalers
 


### PR DESCRIPTION
We don't use underscore for the sensor name in the other repos.