### PR TITLE
Remove unnecessary docker image check

### DIFF
--- a/protoc-gen-doc.sh
+++ b/protoc-gen-doc.sh
@@ -1,18 +1,13 @@
 #!/bin/bash
 
-if [[ "$(docker images -q pseudomuto/protoc-gen-doc:latest 2> /dev/null)" == "" ]]; then
-  echo "Image pseudomuto/protoc-gen-doc:latest not found, run docker pull to install:"
-  echo "docker pull pseudomuto/protoc-gen-doc"
-else
-  echo "Generating Markdown documentation $(pwd)/docs/markdown/protocol.md"
-  docker run --rm \
-    -v $(pwd)/docs/markdown:/out \
-    -v $(pwd)/protobuf_definitions:/protos \
-    pseudomuto/protoc-gen-doc --doc_opt=markdown,protocol.md
+echo "Generating Markdown documentation $(pwd)/docs/markdown/protocol.md"
+docker run --rm \
+  -v $(pwd)/docs/markdown:/out \
+  -v $(pwd)/protobuf_definitions:/protos \
+  pseudomuto/protoc-gen-doc --doc_opt=markdown,protocol.md
 
-  echo "Generating HTML documentation $(pwd)/docs/html/protocol.html"
-  docker run --rm \
-    -v $(pwd)/docs/html:/out \
-    -v $(pwd)/protobuf_definitions:/protos \
-    pseudomuto/protoc-gen-doc --doc_opt=html,protocol.html
-fi
+echo "Generating HTML documentation $(pwd)/docs/html/protocol.html"
+docker run --rm \
+  -v $(pwd)/docs/html:/out \
+  -v $(pwd)/protobuf_definitions:/protos \
+  pseudomuto/protoc-gen-doc --doc_opt=html,protocol.html

--- a/protolint.sh
+++ b/protolint.sh
@@ -1,11 +1,6 @@
 #!/bin/bash
 
-if [[ "$(docker images -q yoheimuta/protolint:v0.31.0 2> /dev/null)" == "" ]]; then
-  echo "Image yoheimuta/protolint:v0.31.0 not found, run docker pull to install:"
-  echo "docker pull yoheimuta/protolint:v0.31.0"
-else
-  docker run --rm \
+docker run --rm \
     -v $(pwd):/workspace \
     --workdir /workspace \
     yoheimuta/protolint:0.44.0 lint protobuf_definitions
-fi


### PR DESCRIPTION
`docker run` will automatically pull the requested image if it's not available locally, so no need to force the user to do it manually.