### PR TITLE
Use C++ style comments

### DIFF
--- a/protobuf_definitions/aquatroll.proto
+++ b/protobuf_definitions/aquatroll.proto
@@ -1,17 +1,13 @@
-/*
- * Aquatroll
- *
- * These messages are emitted by the In-Situ AquaTroll 500 probe.
- */
+// Aquatroll
+//
+// These messages are emitted by the In-Situ AquaTroll 500 probe.
 syntax = "proto3";
 
 package blueye.protocol;
 import "google/protobuf/timestamp.proto";
 option csharp_namespace = "Blueye.Protocol.Protobuf";
 
-/**
-  * Type IDs
-  */
+// Type IDs
 enum Type {
   TYPE_UNSPECIFIED = 0;
   TYPE_SHORT = 1;
@@ -25,9 +21,7 @@ enum Type {
   TYPE_TIME = 9;
 }
 
-/**
-  * Aqua Troll Device IDs
-  */
+// Aqua Troll Device IDs
 enum AquaTrollDevice {
   AQUA_TROLL_DEVICE_UNSPECIFIED = 0;
   AQUA_TROLL_DEVICE_LEVEL_TROLL_500 = 1;
@@ -51,9 +45,7 @@ enum AquaTrollDevice {
   AQUA_TROLL_DEVICE_AQUA_TROLL_500_VENTED = 34;
 }
 
-/**
-  * Aqua Troll Quality IDs
-  */
+// Aqua Troll Quality IDs
 enum AquaTrollQuality {
   AQUA_TROLL_QUALITY_NORMAL = 0; // protolint:disable:this ENUM_FIELD_NAMES_ZERO_VALUE_END_WITH
   AQUA_TROLL_QUALITY_USER_CAL_EXPIRED = 1;
@@ -65,9 +57,7 @@ enum AquaTrollQuality {
   AQUA_TROLL_QUALITY_OFF_LINE = 7;
 }
 
-/**
-  * Aqua Troll Parameter IDs
-  */
+// Aqua Troll Parameter IDs
 enum AquaTrollParameter {
   AQUA_TROLL_PARAMETER_UNSPECIFIED = 0;
   AQUA_TROLL_PARAMETER_TEMPERATURE = 1;
@@ -129,9 +119,7 @@ enum AquaTrollParameter {
   AQUA_TROLL_PARAMETER_COLORED_DISSOLVED_ORGANIC_MATTER_CONCENTRATION = 87;
 }
 
-/**
-  * Aqua Troll Unit IDs
-  */
+// Aqua Troll Unit IDs
 enum AquaTrollUnit {
   AQUA_TROLL_UNIT_UNSPECIFIED = 0;
   AQUA_TROLL_UNIT_TEMP_CELSIUS = 1;
@@ -219,9 +207,7 @@ enum AquaTrollUnit {
   AQUA_TROLL_UNIT_METERS_PER_SECOND = 306;
 }
 
-/**
-  * Aqua Troll Sensor IDs
-  */
+// Aqua Troll Sensor IDs
 enum AquaTrollSensor {
   AQUA_TROLL_SENSOR_UNSPECIFIED = 0;
   AQUA_TROLL_SENSOR_TEMPERATURE = 1;
@@ -284,9 +270,7 @@ enum AquaTrollSensor {
   AQUA_TROLL_SENSOR_PROBE_PARAMETERS = 79;
 }
 
-/**
-  * Aqua Troll Sensor Status IDs
-  */
+// Aqua Troll Sensor Status IDs
 enum AquaTrollSensorStatus {
   AQUA_TROLL_SENSOR_STATUS_SENSOR_HIGH_ALARM = 0; // protolint:disable:this ENUM_FIELD_NAMES_ZERO_VALUE_END_WITH
   AQUA_TROLL_SENSOR_STATUS_SENSOR_HIGH_WARNING = 1;
@@ -298,9 +282,7 @@ enum AquaTrollSensorStatus {
   AQUA_TROLL_SENSOR_STATUS_SENSOR_MODE_BIT_2 = 9;
 }
 
-/**
-  * Aqua Troll Device Status IDs
-  */
+// Aqua Troll Device Status IDs
 enum AquaTrollDeviceStatus {
   AQUA_TROLL_DEVICE_STATUS_SENSOR_HIGH_ALARM = 0; // protolint:disable:this ENUM_FIELD_NAMES_ZERO_VALUE_END_WITH
   AQUA_TROLL_DEVICE_STATUS_SENSOR_HIGH_WARNING = 1;
@@ -318,11 +300,9 @@ enum AquaTrollDeviceStatus {
 }
 
 
-/**
- * In-Situ Parameter Block
- *
- * Up to NUMBER_OF_SENSOR_PARAMETERS blocks may be part of a sensor
- */
+// In-Situ Parameter Block
+//
+// Up to NUMBER_OF_SENSOR_PARAMETERS blocks may be part of a sensor
 message AquaTrollParameterBlock {
   reserved 4;
   reserved "data_quality_id";
@@ -335,14 +315,12 @@ message AquaTrollParameterBlock {
   repeated AquaTrollUnit available_units = 6;
 }
 
-/**
- * In-Situ AquaTroll 500 sensor metadata
- *
- * (Mostly) static information about a connected sensor.
- *
- * Refer to Section 7 Sensor Common Registers in the In-Situ Modbus
- * Communication Protocol
- */
+// In-Situ AquaTroll 500 sensor metadata
+//
+// (Mostly) static information about a connected sensor.
+//
+// Refer to Section 7 Sensor Common Registers in the In-Situ Modbus
+// Communication Protocol
 message AquaTrollSensorMetadata {
   reserved 4;
   reserved "sensor_status";
@@ -415,18 +393,14 @@ message AquaTrollSensorParametersArray {
   repeated AquaTrollSensorParameters sensors = 2;
 }
 
-/**
-  * Request to set an In-Situ Aqua Troll parameter unit
-  */
+// Request to set an In-Situ Aqua Troll parameter unit
 message SetAquaTrollParameterUnit {
   AquaTrollSensor sensor_id = 1; // Sensor id, f. ex. "SENSOR_CONDUCTIVITY_SENSOR"
   AquaTrollParameter parameter_id = 2; // Parameter name, f. ex. "PARAMETER_TEMPERATURE"
   AquaTrollUnit unit_id = 3; // Unit, f. ex. "UNIT_TEMP_CELSIUS"
 }
 
-/**
-  * Request to change the In-Situ Aqua Troll connection status
-  */
+// Request to change the In-Situ Aqua Troll connection status
 message SetAquaTrollConnectionStatus {
   bool connected = 1; // True to connect, false to disconnect
 }

--- a/protobuf_definitions/control.proto
+++ b/protobuf_definitions/control.proto
@@ -1,8 +1,6 @@
-/*
- * Control
- *
- * These messages define control messages accepted by the Blueye drone.
- */
+// Control
+//
+// These messages define control messages accepted by the Blueye drone.
 syntax = "proto3";
 
 package blueye.protocol;
@@ -10,217 +8,155 @@ import "aquatroll.proto";
 import "message_formats.proto";
 option csharp_namespace = "Blueye.Protocol.Protobuf";
 
-/**
-  * Issue a command to move the drone in the surge, sway, heave, or yaw direction.
-  */
+// Issue a command to move the drone in the surge, sway, heave, or yaw direction.
 message MotionInputCtrl {
   MotionInput motion_input = 1; // Message with the desired movement in each direction.
 }
 
-/**
-  * Issue a command to tilt the drone camera.
-  */
+// Issue a command to tilt the drone camera.
 message TiltVelocityCtrl {
   TiltVelocity velocity = 1; // Message with the desired tilt velocity (direction and speed).
 }
 
-/**
-  * Issue a command to set the main light intensity.
-  */
+// Issue a command to set the main light intensity.
 message LightsCtrl {
   Lights lights = 1; // Message with the desired light intensity.
 }
 
-/**
-  * Issue a command to set the guest port light intensity.
-  */
+// Issue a command to set the guest port light intensity.
 message GuestportLightsCtrl {
   Lights lights = 1; // Message with the desired light intensity.
 }
 
-/**
-  * Issue a command to set the laser intensity.
-  */
+// Issue a command to set the laser intensity.
 message LaserCtrl {
   Laser laser = 1; // Message with the desired laser intensity.
 }
 
-/**
-  * Issue a command with the GPS position of the pilot.
-  */
+// Issue a command with the GPS position of the pilot.
 message PilotGPSPositionCtrl {
   LatLongPosition position = 1; // The GPS position of the pilot.
 }
 
-/**
-  * Issue a watchdog message to indicate that the remote client is connected and working as expected.
-  *
-  * If a watchdog message is not received every second, the drone will turn off lights and other auto
-  * functions to indicate that connection with the client has been lost.
-  */
+// Issue a watchdog message to indicate that the remote client is connected and working as expected.
+//
+// If a watchdog message is not received every second, the drone will turn off lights and other auto
+// functions to indicate that connection with the client has been lost.
 message WatchdogCtrl {
   ConnectionDuration connection_duration = 1; // Message with the number of seconds the client has been connected.
   uint32 client_id = 2; // The ID of the client, received in the ConnectClientRep response.
 }
 
-/**
-  * Issue a command to start video recording.
-  */
+// Issue a command to start video recording.
 message RecordCtrl {
   RecordOn record_on = 1; // Message specifying which cameras to record.
 }
 
-/**
-  * Issue a command to take a picture.
-  */
+// Issue a command to take a picture.
 message TakePictureCtrl {
 }
 
-/**
-  * Issue a command to start compass calibration.
-  */
+// Issue a command to start compass calibration.
 message StartCalibrationCtrl {
 }
 
-/**
-  * Issue a command to cancel compass calibration.
-  */
+// Issue a command to cancel compass calibration.
 message CancelCalibrationCtrl {
 }
 
-/**
-  * Issue a command to finish compass calibration.
-  */
+// Issue a command to finish compass calibration.
 message FinishCalibrationCtrl {
 }
 
-/**
-  * Issue a command to set auto heading to a desired state.
-  */
+// Issue a command to set auto heading to a desired state.
 message AutoHeadingCtrl {
   AutoHeadingState state = 1; // State of the heading controller
 }
 
-/**
-  * Issue a command to set auto depth to a desired state.
-  */
+// Issue a command to set auto depth to a desired state.
 message AutoDepthCtrl {
   AutoDepthState state = 1; // State of the depth controller
 }
 
-/**
-  * Issue a command to set auto altitude to a desired state.
-  */
+// Issue a command to set auto altitude to a desired state.
 message AutoAltitudeCtrl {
   AutoAltitudeState state = 1; // State of the altitude controller
 }
 
-/**
-  * Issue a command to set station keeping to a desired state.
-  */
+// Issue a command to set station keeping to a desired state.
 message StationKeepingCtrl {
   StationKeepingState state = 1; // State of the station keeping controller
 }
 
-/**
-  * Issue a command to set station keeping with weather vaning to a desired state.
-  */
+// Issue a command to set station keeping with weather vaning to a desired state.
 message WeatherVaningCtrl {
   WeatherVaningState state = 1; // State of the weather vaning controller
 }
 
-/**
-  * Issue a command to reset the position estimate.
-  */
+// Issue a command to reset the position estimate.
 message ResetPositionCtrl {
   ResetPositionSettings settings = 1; // Reset settings.
 }
 
-/**
-  * Issue a command to reset the odometer.
-  */
+// Issue a command to reset the odometer.
 message ResetOdometerCtrl {
 }
 
-/**
-  * Issue a command to enable or disable tilt stabilization.
-  */
+// Issue a command to enable or disable tilt stabilization.
 message TiltStabilizationCtrl {
   TiltStabilizationState state = 1; // Message with the tilt stabilization state to set.
 }
 
-/**
-  * Issue a command to set the water density.
-  */
+// Issue a command to set the water density.
 message WaterDensityCtrl {
   WaterDensity density = 1; // Message with the water density to set.
 }
 
-/**
-  * Issue a command to set the pinger configuration.
-  */
+// Issue a command to set the pinger configuration.
 message PingerConfigurationCtrl {
   PingerConfiguration configuration = 1; // Message with the pinger configuration to set.
 }
 
-/**
-  * Issue a command to set the system time on the drone.
-  */
+// Issue a command to set the system time on the drone.
 message SystemTimeCtrl {
   SystemTime system_time = 1; // Message with the system time to set.
 }
 
-/**
-  * Issue a command to control the gripper.
-  */
+// Issue a command to control the gripper.
 message GripperCtrl {
   GripperVelocities gripper_velocities = 1; // The desired gripping and rotation velocity.
 }
 
-/**
-  * Issue a command to set a generic servo value.
-  */
+// Issue a command to set a generic servo value.
 message GenericServoCtrl {
   GenericServo servo = 1; // Message with the desired servo value.
 }
 
-/**
-  * Issue a command to set multibeam servo angle.
-  */
+// Issue a command to set multibeam servo angle.
 message MultibeamServoCtrl {
   MultibeamServo servo = 1; // Message with the desired servo angle.
 }
 
-/**
-  * Deactivate the guest port power
-  */
+// Deactivate the guest port power
 message DeactivateGuestPortsCtrl {
 }
 
-/**
-  * Activated the guest port power
-  */
+// Activated the guest port power
 message ActivateGuestPortsCtrl {
 }
 
-/**
-  * Restart the guest ports by turning power on and off
-  */
+// Restart the guest ports by turning power on and off
 message RestartGuestPortsCtrl {
   GuestPortRestartInfo restart_info = 1; // Message with information about how long to keep the guest ports off.
 }
 
-/**
-  * Request to set an In-Situ Aqua Troll parameter unit
-  */
+// Request to set an In-Situ Aqua Troll parameter unit
 message SetAquaTrollParameterUnitCtrl {
   // Message with information about which parameter to set and the unit to set it to.
   SetAquaTrollParameterUnit parameter_info = 1;
 }
 
-/**
-  * Request to change the In-Situ Aqua Troll connection status
-  */
+// Request to change the In-Situ Aqua Troll connection status
 message SetAquaTrollConnectionStatusCtrl {
   // Message with information about which parameter to set and the unit to set it to.
   SetAquaTrollConnectionStatus connection_status = 1;

--- a/protobuf_definitions/message_formats.proto
+++ b/protobuf_definitions/message_formats.proto
@@ -1,8 +1,6 @@
-/**
- * Common messages
- *
- * These are used for logging as well as building requests and responses.
- */
+// Common messages
+//
+// These are used for logging as well as building requests and responses.
 syntax = "proto3";
 
 package blueye.protocol;
@@ -10,27 +8,23 @@ import "google/protobuf/any.proto";
 import "google/protobuf/timestamp.proto";
 option csharp_namespace = "Blueye.Protocol.Protobuf";
 
-/**
-  * Wrapper message for each entry in the drone telemetry logfile.
-  *
-  * Each entry contains the unix timestamp in UTC, the monotonic timestamp (time since boot),
-  * and an Any message wrapping the custom Blueye message.
-  *
-  * See separate documentation for the logfile format for more details.
-  */
+// Wrapper message for each entry in the drone telemetry logfile.
+//
+// Each entry contains the unix timestamp in UTC, the monotonic timestamp (time since boot),
+// and an Any message wrapping the custom Blueye message.
+//
+// See separate documentation for the logfile format for more details.
 message BinlogRecord {
   google.protobuf.Any payload = 1; // The log entry payload.
   google.protobuf.Timestamp unix_timestamp = 2; // Unix timestamp in UTC.
   google.protobuf.Timestamp clock_monotonic = 3; // Posix CLOCK_MONOTONIC timestamp.
 }
 
-/**
- * Motion input from client.
- *
- * Used to indicate the desired motion in each direction.
- * Typically these values map to the left and right joystick for motion,
- * and the left and right trigger for the slow and boost modifiers.
- */
+// Motion input from client.
+//
+// Used to indicate the desired motion in each direction.
+// Typically these values map to the left and right joystick for motion,
+// and the left and right trigger for the slow and boost modifiers.
 message MotionInput {
   float surge = 1; // Forward (positive) and backwards (negative) movement. (-1..1)
   float sway = 2; // Right (positive) and left (negative) lateral movement (-1..1)
@@ -40,77 +34,57 @@ message MotionInput {
   float boost = 6; // Multiplier used to increase the speed of the motion (0..1)
 }
 
-/**
-  * Lights message used to represent the intensity of the main light or external lights.
-  */
+// Lights message used to represent the intensity of the main light or external lights.
 message Lights {
   float value = 1; // Light intensity (0..1)
 }
 
-/**
-  * Laser message used to represent the intensity of connected laser.
-  *
-  * If the laser does not support dimming but only on and off,
-  * a value of 0 turns the laser off, and any value above 0
-  * turns the laser on.
-  */
+// Laser message used to represent the intensity of connected laser.
+//
+// If the laser does not support dimming but only on and off,
+// a value of 0 turns the laser off, and any value above 0
+// turns the laser on.
 message Laser {
   float value = 1; // Laser intensity, any value above 0 turns the laser on (0..1)
 }
 
-/**
-  * Latitude and longitude position in WGS 84 decimal degrees format.
-  */
+// Latitude and longitude position in WGS 84 decimal degrees format.
 message LatLongPosition {
   double latitude = 1; // Latitude (°)
   double longitude = 2; // Longitude (°)
 }
 
-/**
-  * Connection duration of a remote client.
-  */
+// Connection duration of a remote client.
 message ConnectionDuration {
   int32 value = 1; // time since connected to drone (s)
 }
 
-/**
-  * Auto heading state.
-  */
+// Auto heading state.
 message AutoHeadingState {
   bool enabled = 1; // If auto heading is enabled
 }
 
-/**
-  * Auto depth state.
-  */
+// Auto depth state.
 message AutoDepthState {
   bool enabled = 1; // If auto depth is enabled
 }
 
-/**
-  * Auto altitude state.
-  */
+// Auto altitude state.
 message AutoAltitudeState {
   bool enabled = 1; // If auto altitude is enabled
 }
 
-/**
-  * Station keeping state.
-  */
+// Station keeping state.
 message StationKeepingState {
   bool enabled = 1; // If station keeping is enabled
 }
 
-/**
-  * Weather vaning state.
-  */
+// Weather vaning state.
 message WeatherVaningState {
   bool enabled = 1; // If weather vaning is enabled
 }
 
-/**
-  * Control mode from drone supervisor
-  */
+// Control mode from drone supervisor
 message ControlMode {
   bool auto_depth = 1; // If auto depth is enabled
   bool auto_heading = 2; // If auto heading is enabled
@@ -119,34 +93,26 @@ message ControlMode {
   bool weather_vaning = 5; // If weather vaning is enabled
 }
 
-/**
-  * Tilt stabilization state.
-  *
-  * Blueye drones with mechanical tilt has the ability to enable
-  * camera stabilization.
-  */
+// Tilt stabilization state.
+//
+// Blueye drones with mechanical tilt has the ability to enable
+// camera stabilization.
 message TiltStabilizationState {
   bool enabled = 1; // If tilt stabilization is enabled
 }
 
-/**
-  * System time.
-  */
+// System time.
 message SystemTime {
   google.protobuf.Timestamp unix_timestamp = 1; // Unix timestamp
 }
 
-/**
-  * Gripper velocity values.
-  */
+// Gripper velocity values.
 message GripperVelocities {
   float grip_velocity = 1; // The gripping velocity (-1.0..1.0)
   float rotate_velocity = 2; // The rotating velocity (-1.0..1.0)
 }
 
-/**
-  * Information about a remote client.
-  */
+// Information about a remote client.
 message ClientInfo {
   string type = 1; // The type of client (such as Blueye App, Observer App, SDK, etc)
   string version = 2; // Client software version string
@@ -156,17 +122,13 @@ message ClientInfo {
   string name = 6; // Name of the client
 }
 
-/**
-  * Information about a connected client with an id assigned by the drone.
-  */
+// Information about a connected client with an id assigned by the drone.
 message ConnectedClient {
   uint32 client_id = 1; // The assigned client id
   ClientInfo client_info = 2; // Client information.
 }
 
-/**
-  * Camera recording state.
-  */
+// Camera recording state.
 message RecordState {
   bool main_is_recording = 1; // If the main camera is recording
   int32 main_seconds = 2; // Main record time (s)
@@ -174,21 +136,17 @@ message RecordState {
   int32 guestport_seconds = 4; // Guestport record time (s)
 }
 
-/**
-  * Water density.
-  *
-  * Used to specify the water density the drone is operating in,
-  * to achieve more accruate depth measurements.
-  */
+// Water density.
+//
+// Used to specify the water density the drone is operating in,
+// to achieve more accruate depth measurements.
 message WaterDensity {
   float value = 1; // Salinity (kg/l)
 }
 
-/**
-  * Pinger configuration.
-  *
-  * Used to specify the configuration the BR 1D-Pinger.
-  */
+// Pinger configuration.
+//
+// Used to specify the configuration the BR 1D-Pinger.
 message PingerConfiguration {
   enum MountingDirection {
     MOUNTING_DIRECTION_UNSPECIFIED = 0; // Mounting direction is unspecified
@@ -199,61 +157,47 @@ message PingerConfiguration {
   MountingDirection mounting_direction = 1; // Mounting direction of the pinger
 }
 
-/**
- * Water temperature measured by the drone's combined depth and temperature sensor.
- */
+// Water temperature measured by the drone's combined depth and temperature sensor.
 message WaterTemperature {
   float value = 1; // Water temperature (°C)
 }
 
-/**
- * CPU temperature.
- */
+// CPU temperature.
 message CPUTemperature {
   float value = 1; // CPU temperature (°C)
 }
 
-/**
-  * Canister temperature.
-  *
-  * Temperature measured in the top or bottom canister of the drone.
-  */
+// Canister temperature.
+//
+// Temperature measured in the top or bottom canister of the drone.
 message CanisterTemperature {
   reserved 1, 2;
   float temperature = 3; // Temperature (°C)
 }
 
-/**
-  * Canister humidity.
-  *
-  * Humidity measured in the top or bottom canister of the drone.
-  */
+// Canister humidity.
+//
+// Humidity measured in the top or bottom canister of the drone.
 message CanisterHumidity {
   reserved 1, 2;
   float humidity = 3; // Air humidity (%)
 }
 
-/**
-  * Essential battery information.
-  */
+// Essential battery information.
 message Battery {
   float voltage = 1; // Battery voltage (V)
   float level = 2; // Battery level (0..1)
   float temperature = 3; // Battery temperature (°C)
 }
 
-/**
-  * Battery information message.
-  *
-  * Detailed information about all aspects of the connected Blueye Smart Battery,
-  * using the BQ40Z50 BMS.
-  */
+// Battery information message.
+//
+// Detailed information about all aspects of the connected Blueye Smart Battery,
+// using the BQ40Z50 BMS.
 message BatteryBQ40Z50 {
   reserved 3, 5;
 
-  /**
-    * Battery voltage levels.
-    */
+  // Battery voltage levels.
   message Voltage {
     float total = 1; // Battery pack voltage level (V)
     float cell_1 = 2; // Cell 1 voltage level (V)
@@ -263,9 +207,7 @@ message BatteryBQ40Z50 {
   }
   Voltage voltage = 1; // Voltage of the battery cells
 
-  /**
-   * Battery temperature.
-   */
+  // Battery temperature.
   message Temperature {
     float average = 1; // Average temperature accross cells (°C)
     float cell_1 = 2; // Cell 1 temperature (°C)
@@ -275,9 +217,7 @@ message BatteryBQ40Z50 {
   }
   Temperature temperature = 2; // Temperature of the battery cells
 
-  /**
-    * Battery status from BQ40Z50 ref data sheet 0x16.
-    */
+  // Battery status from BQ40Z50 ref data sheet 0x16.
   message BatteryStatus {
     reserved 15, 16;
     bool overcharged_alarm = 1;
@@ -291,9 +231,7 @@ message BatteryBQ40Z50 {
     bool fully_charged = 9;
     bool fully_discharged = 10;
 
-    /**
-      * Battery errror code from BQ40Z50 BMS data sheet.
-      */
+    // Battery errror code from BQ40Z50 BMS data sheet.
     enum BatteryError {
       BATTERY_ERROR_UNSPECIFIED = 0;
       BATTERY_ERROR_OK = 1;
@@ -331,35 +269,27 @@ message BatteryBQ40Z50 {
   string device_chemistry = 25; // Battery chemistry
 }
 
-/**
- * The attitude of the drone.
- */
+// The attitude of the drone.
 message Attitude {
   float roll = 1; // Roll angle (-180°..180°)
   float pitch = 2; // Pitch angle (-180°..180°)
   float yaw = 3; // Yaw angle (-180°..180°)
 }
 
-/**
- * Drone altitude over seabed, typically obtained from a DVL.
- */
+// Drone altitude over seabed, typically obtained from a DVL.
 message Altitude {
   float value = 1; // Drone altitude over seabed (m)
   bool is_valid = 2; // If altitude is valid or not
 }
 
-/**
- * Distance to an object infront of the drone, typically obtained from an 1D
- * pinger.
- */
+// Distance to an object infront of the drone, typically obtained from an 1D
+// pinger.
 message ForwardDistance {
   float value = 1; // Distance in front of drone (m)
   bool is_valid = 2; // If distance reading is valid or not
 }
 
-/**
- * Position estimate from the Extended Kalman filter based observer if a DVL is connected.
- */
+// Position estimate from the Extended Kalman filter based observer if a DVL is connected.
 message PositionEstimate {
   float northing = 1; // Position from reset point (m)
   float easting = 2; // Position from reset point (m)
@@ -374,18 +304,14 @@ message PositionEstimate {
   repeated NavigationSensorStatus navigation_sensors = 11; // List of available sensors with status
 }
 
-/**
-  * Heading source used during reset of the position estimate.
-  */
+// Heading source used during reset of the position estimate.
 enum HeadingSource {
   HEADING_SOURCE_UNSPECIFIED = 0; // Unspecified
   HEADING_SOURCE_DRONE_COMPASS = 1; // Uses the drone compass to set the heading
   HEADING_SOURCE_MANUAL_INPUT = 2; // Used when the user sets the heading manually
 }
 
-/**
-  * ResetPositionSettings used during reset of the position estimate.
-  */
+// ResetPositionSettings used during reset of the position estimate.
 message ResetPositionSettings {
   HeadingSource heading_source_during_reset = 1; // Option to use the drone compass or due North as heading during reset
   float manual_heading = 2; // Heading in degrees (0-359)
@@ -399,17 +325,13 @@ enum ResetCoordinateSource {
   RESET_COORDINATE_SOURCE_MANUAL = 2; // Uses a coordinate in decimal degrees to set the reset point
 }
 
-/**
- * Water depth of the drone.
- */
+// Water depth of the drone.
 message Depth {
   float value = 1; // Drone depth below surface (m)
 }
 
-/**
- * Reference for the control system. Note that the internal heading referece is not relative to North.
- * Use (ControlHealth.heading_error + pose.yaw) instead.
- */
+// Reference for the control system. Note that the internal heading referece is not relative to North.
+// Use (ControlHealth.heading_error + pose.yaw) instead.
 message Reference {
   float surge = 1; // Reference from joystick surge input (0..1)
   float sway = 2; // Reference from joystick sway input (0..1)
@@ -420,9 +342,7 @@ message Reference {
   float altitude = 7; // Reference used in auto altitude mode (m)
 }
 
-/**
- * Control Force is used for showing the requested control force in each direction in Newtons.
- */
+// Control Force is used for showing the requested control force in each direction in Newtons.
 message ControlForce {
   float surge = 1; // Force in surge (N)
   float sway = 2; // Force in sway (N)
@@ -430,9 +350,7 @@ message ControlForce {
   float yaw = 4; // Moment in yaw (Nm)
 }
 
-/**
- * Controller health is used for showing the state of the controller with an relative error and load from 0 to 1.
- */
+// Controller health is used for showing the state of the controller with an relative error and load from 0 to 1.
 message ControllerHealth {
   float depth_error = 1; // Depth error in meters (m)
   float depth_health = 2; // Depth controller load (0..1)
@@ -440,41 +358,31 @@ message ControllerHealth {
   float heading_health = 4; // Heading controller load (0..1)
 }
 
-/**
-  * Amount of time the drone has been submerged.
-  *
-  * The drone starts incrementing this value when the depth is above 250 mm.
-  */
+// Amount of time the drone has been submerged.
+//
+// The drone starts incrementing this value when the depth is above 250 mm.
 message DiveTime {
   int32 value = 1; // Number of seconds the drone has been submerged
 }
 
-/**
-  * Which cameras are supposed to be recording
-  */
+// Which cameras are supposed to be recording
 message RecordOn {
   bool main = 1; // Record the main camera
   bool guestport = 2; // Record external camera
 }
 
-/**
-  * Storage space.
-  */
+// Storage space.
 message StorageSpace {
   int64 total_space = 1; // Total bytes of storage space (B)
   int64 free_space = 2; // Available bytes of storage space (B)
 }
 
-/**
-  * Compass calibration state.
-  */
+// Compass calibration state.
 message CalibrationState {
 
-  /**
-   * Status of the compass calibration procedure.
-   *
-   * When calibration is started, the status will indicate the active (upfacing) axis.
-   */
+  // Status of the compass calibration procedure.
+  //
+  // When calibration is started, the status will indicate the active (upfacing) axis.
   enum Status
   {
     STATUS_UNSPECIFIED = 0; // Unspecified status
@@ -499,39 +407,29 @@ message CalibrationState {
   float progress_thruster = 8; // Progress for the thruster calibration (0..1)
 }
 
-/**
-  * Connection speed between drone and Surface Unit.
-  */
+// Connection speed between drone and Surface Unit.
 message IperfStatus {
   float sent = 1; // Transfer rate from drone to Surface Unit (Mbit/s)
   float received = 2; // Transfer rate from Surface Unit to drone (Mbit/s)
 }
 
-/**
- * Number of spectators connected to video stream.
- */
+// Number of spectators connected to video stream.
 message NStreamers {
   int32 main = 1; // The number of clients to the main camera stream
   int32 guestport = 2; // The number of clients to the guestport camera stream
 }
 
-/**
- * Angle of tilt camera in degrees.
- */
+// Angle of tilt camera in degrees.
 message TiltAngle {
   float value = 1; // Tilt angle (°)
 }
 
-/**
- * Relative velocity of tilt
- */
+// Relative velocity of tilt
 message TiltVelocity {
   float value = 1; // Relative angular velocity of tilt (-1..1), negative means down and positive means up
 }
 
-/**
-  * Drone models produced by Blueye
-  */
+// Drone models produced by Blueye
 enum Model {
   MODEL_UNSPECIFIED = 0; // ModelName not specified
   MODEL_PIONEER = 1; // Blueye Pioneer, the first model
@@ -540,9 +438,7 @@ enum Model {
   MODEL_X3 = 3; // Blueye X3, features support for peripherals
 }
 
-/**
-  * Depth sensors used by the drone.
-  */
+// Depth sensors used by the drone.
 enum PressureSensorType {
   PRESSURE_SENSOR_TYPE_UNSPECIFIED = 0; // Depth sensor type not specified
   PRESSURE_SENSOR_TYPE_NOT_CONNECTED = 1; // No se
@@ -551,13 +447,11 @@ enum PressureSensorType {
   PRESSURE_SENSOR_TYPE_MS5637_02BA03 = 4; // The internal pressure sensor using the MS5637 02BA03 pressure sensor
 }
 
-/**
-  * Information about the drone.
-  *
-  * This message contains serial numbers and version information for
-  * internal components in the drone. Primarily used for diagnostics, or to
-  * determine the origin of a logfile.
-  */
+// Information about the drone.
+//
+// This message contains serial numbers and version information for
+// internal components in the drone. Primarily used for diagnostics, or to
+// determine the origin of a logfile.
 message DroneInfo {
   string blunux_version = 1; // Blunux version string
   bytes serial_number = 2; // Drone serial number
@@ -572,9 +466,7 @@ message DroneInfo {
   PressureSensorType depth_sensor = 11; // Type of depth sensor that is connected to the drone
 }
 
-/**
-  * Known error states for the drone.
-  */
+// Known error states for the drone.
 message ErrorFlags {
   // Acknowledge message not received for a message published to internal micro controller
   bool pmu_comm_ack = 1;
@@ -621,36 +513,28 @@ message ErrorFlags {
   bool gp_20v_current = 42;  // Max 20V current exceeded on GP
 }
 
-/**
-  * Available camera resolutions.
-  */
+// Available camera resolutions.
 enum Resolution {
   RESOLUTION_UNSPECIFIED = 0; // Resolution not specified
   RESOLUTION_FULLHD_1080P = 1; // 1080p Full HD resolution
   RESOLUTION_HD_720P = 2; // 720p HD resolution
 }
 
-/**
-  * Available camera framerates.
-  */
+// Available camera framerates.
 enum Framerate {
   FRAMERATE_UNSPECIFIED = 0; // Framerate not specified
   FRAMERATE_FPS_30 = 1; // 30 frames per second
   FRAMERATE_FPS_25 = 2; // 25 frames per second
 }
 
-/**
-  * Which camera to control.
-  */
+// Which camera to control.
 enum Camera {
   CAMERA_UNSPECIFIED = 0; // Camera not specified
   CAMERA_MAIN = 1; // Main camera
   CAMERA_GUESTPORT = 2; // Guestport camera
 }
 
-/**
-  * Camera parameters.
-  */
+// Camera parameters.
 message CameraParameters {
   int32 h264_bitrate = 1; // Bitrate of the h264 stream (bit/sec)
   int32 mjpg_bitrate = 2; // Bitrate of the MJPG stream used for still pictures (bit/sec)
@@ -665,18 +549,14 @@ message CameraParameters {
   Camera camera = 8; // Which camera the parameters belong to.
 }
 
-/**
-  * Available temperature units.
-  */
+// Available temperature units.
 enum TemperatureUnit {
   TEMPERATURE_UNIT_UNSPECIFIED = 0; // Temperature unit not specfied
   TEMPERATURE_UNIT_CELSIUS = 1; // Temperature should be displayed as Celcius
   TEMPERATURE_UNIT_FAHRENHEIT = 2; // Temperature should be displayed as Fahrenheit
 }
 
-/**
-  * Available logo types.
-  */
+// Available logo types.
 enum LogoType {
   LOGO_TYPE_UNSPECIFIED = 0; // Logo type not specified
   LOGO_TYPE_NONE = 1; // Do not add any logo
@@ -684,27 +564,21 @@ enum LogoType {
   LOGO_TYPE_CUSTOM = 3; // Add user defined logo
 }
 
-/**
-  * Available depth units.
-  */
+// Available depth units.
 enum DepthUnit {
   DEPTH_UNIT_UNSPECIFIED = 0; // Depth unit not specified
   DEPTH_UNIT_METERS = 1; // Depth should be displayed as meters
   DEPTH_UNIT_FEET = 2; // Depth should be displayed as feet
 }
 
-/**
-  * Available thickness units.
-  */
+// Available thickness units.
 enum ThicknessUnit {
   THICKNESS_UNIT_UNSPECIFIED = 0; // Thickness unit not specified
   THICKNESS_UNIT_MILLIMETERS = 1; // Thickness should be displayed as millimeters
   THICKNESS_UNIT_INCHES = 2; // Thickness should be displayed as inches
 }
 
-/**
-  * Available font sizes for overlay text elements.
-  */
+// Available font sizes for overlay text elements.
 enum FontSize {
   FONT_SIZE_UNSPECIFIED = 0; // Font size not specified
   FONT_SIZE_PX15 = 1; // 15 px
@@ -715,11 +589,9 @@ enum FontSize {
   FONT_SIZE_PX40 = 6; // 40 px
 }
 
-/**
- * Overlay parameters.
- *
- * All available parameters that can be used to configure telemetry overlay on video recordings.
- */
+// Overlay parameters.
+//
+// All available parameters that can be used to configure telemetry overlay on video recordings.
 message OverlayParameters {
   bool temperature_enabled = 1; // If temperature should be included
   bool depth_enabled = 2; // If depth should be included
@@ -746,9 +618,7 @@ message OverlayParameters {
   float shading = 17; // Pixel intensity to subtract from text background (0..1), 0: transparent, 1: black
 }
 
-/**
- * GuestPort device ID.
- */
+// GuestPort device ID.
 enum GuestPortDeviceID {
   GUEST_PORT_DEVICE_ID_UNSPECIFIED = 0; // Unspecified
   GUEST_PORT_DEVICE_ID_BLIND_PLUG = 1; // Blueye blind plug
@@ -783,9 +653,7 @@ enum GuestPortDeviceID {
   GUEST_PORT_DEVICE_ID_BLUEPRINT_SUBSEA_OCULUS_M3000D = 30; // Blueprint Subsea Oculus M3000d
 }
 
-/**
- * GuestPort number.
- */
+// GuestPort number.
 enum GuestPortNumber {
   GUEST_PORT_NUMBER_UNSPECIFIED = 0; // Unspecified
   GUEST_PORT_NUMBER_PORT_1 = 1; // Guest port 1
@@ -793,9 +661,7 @@ enum GuestPortNumber {
   GUEST_PORT_NUMBER_PORT_3 = 3; // Guest port 3
 }
 
-/**
- * List of navigation sensors that can be used by the position observer
- */
+// List of navigation sensors that can be used by the position observer
 enum NavigationSensorID {
   NAVIGATION_SENSOR_ID_UNSPECIFIED = 0; // Unspecified
   NAVIGATION_SENSOR_ID_WATERLINKED_DVL_A50 = 1; // Water Linked DVL A50
@@ -803,17 +669,13 @@ enum NavigationSensorID {
   NAVIGATION_SENSOR_ID_NMEA = 3; // NMEA stream from external positioning system
 }
 
-/**
- * Navigation sensor used in the position observer with validity state
- */
+// Navigation sensor used in the position observer with validity state
 message NavigationSensorStatus {
   NavigationSensorID sensor_id = 1; // Sensor id
   bool is_valid = 2; // Sensor validity
 }
 
-/**
- * GuestPort device.
- */
+// GuestPort device.
 message GuestPortDevice {
   GuestPortDeviceID device_id = 1; // Blueye device identifier
   string manufacturer = 2; // Manufacturer name
@@ -823,16 +685,12 @@ message GuestPortDevice {
   string required_blunux_version = 6; // Required Blunux version (x.y.z)
 }
 
-/**
- * List of guest port devices.
- */
+// List of guest port devices.
 message GuestPortDeviceList {
   repeated GuestPortDevice devices = 1; // List of guest port devices
 }
 
-/**
- * GuestPort error.
- */
+// GuestPort error.
 enum GuestPortError {
   GUEST_PORT_ERROR_UNSPECIFIED = 0; // Unspecified value
   GUEST_PORT_ERROR_NOT_CONNECTED = 1; // Device not connected
@@ -842,9 +700,7 @@ enum GuestPortError {
   GUEST_PORT_ERROR_PARSE_ERROR = 5; // Protobuf message cannot be parsed
 }
 
-/**
- * GuestPort connector information.
- */
+// GuestPort connector information.
 message GuestPortConnectorInfo {
   oneof connected_device {
     GuestPortDeviceList device_list = 1; // List of devices on this connector
@@ -853,25 +709,19 @@ message GuestPortConnectorInfo {
   GuestPortNumber guest_port_number = 3; // Guest port the connector is connected to
 }
 
-/**
- * GuestPort information.
- */
+// GuestPort information.
 message GuestPortInfo {
   GuestPortConnectorInfo gp1 = 1; // GuestPortConnectorInfo 1
   GuestPortConnectorInfo gp2 = 2; // GuestPortConnectorInfo 2
   GuestPortConnectorInfo gp3 = 3; // GuestPortConnectorInfo 3
 }
 
-/**
-  * GuestPort restart information.
-  */
+// GuestPort restart information.
 message GuestPortRestartInfo {
   double power_off_duration = 1; // Duration to keep the guest ports off (s)
 }
 
-/**
- * Thickness measurement data from a Cygnus Thickness Gauge.
- */
+// Thickness measurement data from a Cygnus Thickness Gauge.
 message ThicknessGauge {
   float thickness_measurement = 1; // Thickness measurement of a steel plate
   uint32 echo_count = 2; // Indicating the quality of the reading when invalid (0-3)
@@ -879,32 +729,24 @@ message ThicknessGauge {
   bool is_measurement_valid = 4; // Indicating if the measurement is valid
 }
 
-/**
- * Reading from a Cathodic Protection Potential probe.
- */
+// Reading from a Cathodic Protection Potential probe.
 message CpProbe {
   float measurement = 1; // Potential measurement (V)
   bool is_measurement_valid = 2; // Indicating if the measurement is valid
 }
 
-/**
-  * Servo message used to represent the angle of the servo.
-  */
+// Servo message used to represent the angle of the servo.
 message GenericServo {
   float value = 1; // Servo value (0..1)
   GuestPortNumber guest_port_number = 2; // Guest port the servo is on
 }
 
-/**
-  * Servo message used to represent the angle of the servo.
-  */
+// Servo message used to represent the angle of the servo.
 message MultibeamServo {
   float angle = 1; // Servo degrees (-30..30)
 }
 
-/**
-  * GuestPort current readings.
-  */
+// GuestPort current readings.
 message GuestPortCurrent {
   double gp1_bat = 1; // Current on GP1 battery voltage (A)
   double gp2_bat = 2; // Current on GP2 battery voltage (A)
@@ -912,22 +754,18 @@ message GuestPortCurrent {
   double gp_20v = 4; // Current on common 20V supply (A)
 }
 
-/**
-  * Vector with 3 elements
-  */
+// Vector with 3 elements
 message Vector3 {
   double x = 1; // x-component
   double y = 2; // y-component
   double z = 3; // z-component
 }
 
-/**
-  * Imu data in drone body frame
-  *
-  * x - forward
-  * y - right
-  * z - down
-  */
+// Imu data in drone body frame
+//
+// x - forward
+// y - right
+// z - down
 message Imu {
   Vector3 accelerometer = 1; // Acceleration (g)
   Vector3 gyroscope = 2; // Angular velocity (rad/s)
@@ -935,9 +773,7 @@ message Imu {
   float temperature = 4; // Temperature (°C)
 }
 
-/**
-  * Medusa gamma ray sensor spectrometer data
-  */
+// Medusa gamma ray sensor spectrometer data
 message MedusaSpectrometerData {
   google.protobuf.Timestamp drone_time = 6; // Time stamp when the data is received
   google.protobuf.Timestamp sensor_time = 7; // Time stamp the sensor reports

--- a/protobuf_definitions/req_rep.proto
+++ b/protobuf_definitions/req_rep.proto
@@ -1,8 +1,6 @@
-/**
- * Request reply
- *
- * These messages define request / reply messages for the Blueye drone.
- */
+// Request reply
+//
+// These messages define request / reply messages for the Blueye drone.
 syntax = "proto3";
 
 package blueye.protocol;
@@ -11,183 +9,135 @@ import "google/protobuf/any.proto";
 import "message_formats.proto";
 option csharp_namespace = "Blueye.Protocol.Protobuf";
 
-/**
-  * Request to set video overlay parameters.
-  */
+// Request to set video overlay parameters.
 message SetOverlayParametersReq {
   OverlayParameters overlay_parameters = 1; // The video overlay parameters to apply.
 }
 
-/**
-  * Response after setting video overlay parameters.
-  */
+// Response after setting video overlay parameters.
 message SetOverlayParametersRep {
 }
 
-/**
-  * Request to get currently set video overlay parameters.
-  */
+// Request to get currently set video overlay parameters.
 message GetOverlayParametersReq {
 }
 
-/**
-  * Response with the currently set video overlay parameters.
-  */
+// Response with the currently set video overlay parameters.
 message GetOverlayParametersRep {
   OverlayParameters overlay_parameters = 1; // The currently set overlay parameters.
 }
 
-/**
-  * Request to set camera parameters.
-  */
+// Request to set camera parameters.
 message SetCameraParametersReq {
   CameraParameters camera_parameters = 1; // The camera parameters to apply.
 }
 
-/**
-  * Response after setting the camera parameters.
-  */
+// Response after setting the camera parameters.
 message SetCameraParametersRep {
 }
 
-/**
-  * Request to get the currently set camera parameters.
-  */
+// Request to get the currently set camera parameters.
 message GetCameraParametersReq {
   Camera camera = 1; // Which camera to read camera parameters from.
 }
 
-/**
-  * Response with the currently set camera parameters.
-  */
+// Response with the currently set camera parameters.
 message GetCameraParametersRep {
   CameraParameters camera_parameters = 1; // The currently set camera parameters.
 }
 
-/**
-  * Request to set the system time on the drone.
-  */
+// Request to set the system time on the drone.
 message SyncTimeReq {
   SystemTime time = 1; // The time to set on the drone.
 }
 
-/**
-  * Response after setting the system time on the drone.
-  */
+// Response after setting the system time on the drone.
 message SyncTimeRep {
   bool success = 1; // If the time was set successfully.
 }
 
-/**
-  * The simplest message to use to test request/reply communication with the drone.
-  *
-  * The drone replies with a PingRep message immediately after receiving the PingReq.
-  */
+// The simplest message to use to test request/reply communication with the drone.
+//
+// The drone replies with a PingRep message immediately after receiving the PingReq.
 message PingReq {
 }
 
-/**
-  * Response message from a PingReq request.
-  */
+// Response message from a PingReq request.
 message PingRep {
 }
 
-/**
-  * Request to set parameters for ultrasonic thickness gauge.
-  *
-  * The sound velocity is used to calculate the thickness of the material being measured.
-  */
+// Request to set parameters for ultrasonic thickness gauge.
+//
+// The sound velocity is used to calculate the thickness of the material being measured.
 message SetThicknessGaugeParametersReq {
   uint32 sound_velocity = 1; // Sound velocity in m/s
 }
 
-/**
-  * Response after setting thicknes gauge parameters.
-  */
+// Response after setting thicknes gauge parameters.
 message SetThicknessGaugeParametersRep {
 }
 
-/**
-  * Connect a new client to the drone.
-  */
+// Connect a new client to the drone.
 message ConnectClientReq {
   ClientInfo client_info = 1; // Information about the client connecting to the drone.
 }
 
-/**
-  * Response after connecting a client to the drone.
-  *
-  * Contains information about which client is in control, and a list of
-  * all connected clients.
-  */
+// Response after connecting a client to the drone.
+//
+// Contains information about which client is in control, and a list of
+// all connected clients.
 message ConnectClientRep {
   uint32 client_id = 1; // The assigned ID of this client.
   uint32 client_id_in_control = 2; // The ID of the client in control of the drone.
   repeated ConnectedClient connected_clients = 3; // List of connected clients.
 }
 
-/**
-  * Disconnect a client from the drone.
-  *
-  * This request will remove the client from the list of connected clients.
-  * It allows clients to disconnect instantly, without waiting for a watchdog to
-  * clear the client in control, or promote a new client to be in control.
-  */
+// Disconnect a client from the drone.
+//
+// This request will remove the client from the list of connected clients.
+// It allows clients to disconnect instantly, without waiting for a watchdog to
+// clear the client in control, or promote a new client to be in control.
 message DisconnectClientReq {
   uint32 client_id = 1; // The assigned ID of the client to disconnect.
 }
 
-/**
-  * Response after disconnecting a client from the drone.
-  *
-  * Contains information about which clients are connected and in control.
-  */
+// Response after disconnecting a client from the drone.
+//
+// Contains information about which clients are connected and in control.
 message DisconnectClientRep {
   uint32 client_id_in_control = 1; // The ID of the client in control of the drone.
   repeated ConnectedClient connected_clients = 2; // List of connected clients.
 }
 
-/**
-  * Request essential battery information.
-  *
-  * Can be used to instantly get battery information,
-  * instead of having to wait for the BatteryTel message to be received.
-  */
+// Request essential battery information.
+//
+// Can be used to instantly get battery information,
+// instead of having to wait for the BatteryTel message to be received.
 message GetBatteryReq {
 }
 
-/**
-  * Response with essential battery information.
-  */
+// Response with essential battery information.
 message GetBatteryRep {
   Battery battery = 1; // Essential battery information.
 }
 
-/**
-  * Request to update the publish frequency
-  */
+// Request to update the publish frequency
 message SetPubFrequencyReq {
   string message_type = 1; // Message name, f. ex. "AttitudeTel"
   float frequency = 2; // Publish frequency (max 100 Hz).
 }
 
-/**
-  * Response after updating publish frequency
-  */
+// Response after updating publish frequency
 message SetPubFrequencyRep {
   bool success = 1; // True if message name valid and frequency successfully updated.
 }
 
-/**
-  * Request to get latest telemetry data
-  */
+// Request to get latest telemetry data
 message GetTelemetryReq {
   string message_type = 1; // Message name, f. ex. "AttitudeTel"
 }
 
-/**
- * Response with latest telemetry
- */
+// Response with latest telemetry
 message GetTelemetryRep {
   google.protobuf.Any payload = 1; // The latest telemetry data, empty if no data available.
 }

--- a/protobuf_definitions/telemetry.proto
+++ b/protobuf_definitions/telemetry.proto
@@ -1,8 +1,6 @@
-/*
- * Telemetry
- *
- * These messages define telemetry messages from the Blueye drone.
- */
+// Telemetry
+//
+// These messages define telemetry messages from the Blueye drone.
 syntax = "proto3";
 
 package blueye.protocol;
@@ -10,16 +8,12 @@ import "aquatroll.proto";
 import "message_formats.proto";
 option csharp_namespace = "Blueye.Protocol.Protobuf";
 
-/**
-  * Receive the current attitude of the drone.
-  */
+// Receive the current attitude of the drone.
 message AttitudeTel {
   Attitude attitude = 1; // The attitude of the drone.
 }
 
-/**
-  * Receive the current altitude of the drone.
-  */
+// Receive the current altitude of the drone.
 message AltitudeTel {
   Altitude altitude = 1; // The altitude of the drone.
 }
@@ -48,23 +42,17 @@ message ControllerHealthTel {
   ControllerHealth controller_health = 1;
 }
 
-/**
-  * Receive the status of the main lights of the drone.
-  */
+// Receive the status of the main lights of the drone.
 message LightsTel {
   Lights lights = 1;
 }
 
-/**
-  * Receive the status of any guest port lights connected to the drone.
-  */
+// Receive the status of any guest port lights connected to the drone.
 message GuestPortLightsTel {
   Lights lights = 1;
 }
 
-/**
-  * Receive the status of any lasers connected to the drone.
-  */
+// Receive the status of any lasers connected to the drone.
 message LaserTel {
   Laser laser = 1;
 }
@@ -77,31 +65,23 @@ message RecordStateTel {
   RecordState record_state = 1;
 }
 
-/*
- * Receive essential information about the battery status.
- */
+// Receive essential information about the battery status.
 message BatteryTel {
   Battery battery = 1; // Essential battery information.
 }
 
-/*
- * Receive detailed information about a battery using the
- * BQ40Z50 battery management system.
- */
+// Receive detailed information about a battery using the
+// BQ40Z50 battery management system.
 message BatteryBQ40Z50Tel {
   BatteryBQ40Z50 battery = 1; // Detailed battery information.
 }
 
-/*
- * Receive the dive time of the drone.
- */
+// Receive the dive time of the drone.
 message DiveTimeTel {
   DiveTime dive_time = 1; // The current dive time of the drone.
 }
 
-/*
- * Receive time information from the drone.
- */
+// Receive time information from the drone.
 message DroneTimeTel {
   SystemTime real_time_clock = 1; // The real-time clock of the drone.
   SystemTime monotonic_clock = 2; // The monotonic clock of the drone (time since power on).
@@ -115,30 +95,22 @@ message CPUTemperatureTel {
   CPUTemperature temperature = 1;
 }
 
-/*
- * Receive temperature information from the top canister.
- */
+// Receive temperature information from the top canister.
 message CanisterTopTemperatureTel {
   CanisterTemperature temperature = 1; // Temperature information.
 }
 
-/*
- * Receive temperature information from the bottom canister.
- */
+// Receive temperature information from the bottom canister.
 message CanisterBottomTemperatureTel {
   CanisterTemperature temperature = 1; // Temperature information.
 }
 
-/*
- * Receive humidity information from the top canister.
- */
+// Receive humidity information from the top canister.
 message CanisterTopHumidityTel {
   CanisterHumidity humidity = 1; // Humidity information
 }
 
-/*
- * Receive humidity information from the bottom canister.
- */
+// Receive humidity information from the bottom canister.
 message CanisterBottomHumidityTel {
   CanisterHumidity humidity = 1; // Humidity information
 }
@@ -171,116 +143,84 @@ message TiltAngleTel {
   TiltAngle angle = 1;
 }
 
-/*
- * Receive metadata and information about the connected drone.
- */
+// Receive metadata and information about the connected drone.
 message DroneInfoTel {
   DroneInfo drone_info = 1; // Various metadata such as software versions and serial number.
 }
 
-/**
-  * Receive currently set error flags.
-  */
+// Receive currently set error flags.
 message ErrorFlagsTel {
   ErrorFlags error_flags = 1; // Currently set error flags on the drone.
 }
 
-/**
- * Receive the current state of the control system.
- */
+// Receive the current state of the control system.
 message ControlModeTel {
   ControlMode state = 1;  // State of the control system.
 }
 
-/**
-  * Thickness gauge measurement telemetry message.
-  */
+// Thickness gauge measurement telemetry message.
 message ThicknessGaugeTel {
   ThicknessGauge thickness_gauge = 1;  // Tickness measurement with a cygnus gauge.
 }
 
-/**
-  * Cathodic Protection Potential probe telemetry message
-  */
+// Cathodic Protection Potential probe telemetry message
 message CpProbeTel {
   CpProbe cp_probe = 1; // Reading from cp probe.
 }
 
 
-/**
-  * Metadata from the In-Situ Aqua Troll probe's common registers
-  */
+// Metadata from the In-Situ Aqua Troll probe's common registers
 message AquaTrollProbeMetadataTel {
   AquaTrollProbeMetadata probe = 1; // AquaTroll message containing sensor array.
 }
 
-/**
-  * Metadata from a single sensor from In-Situ Aqua Troll probe
-  */
+// Metadata from a single sensor from In-Situ Aqua Troll probe
 message AquaTrollSensorMetadataTel {
   AquaTrollSensorMetadataArray sensors = 1; // AquaTroll message containing sensor array.
 }
 
-/**
-  * Single sensor from In-Situ Aqua Troll probe
-  */
+// Single sensor from In-Situ Aqua Troll probe
 message AquaTrollSensorParametersTel {
   AquaTrollSensorParametersArray sensors = 1; // AquaTroll message containing parameter array.
 }
 
-/**
-  * List of connected clients telemetry message.
-  */
+// List of connected clients telemetry message.
 message ConnectedClientsTel {
   uint32 client_id_in_control = 1; // The client id of the client in control.
   repeated ConnectedClient connected_clients = 2; // List of connected clients.
 }
 
-/**
-  * State of a generic servo
-  */
+// State of a generic servo
 message GenericServoTel {
   GenericServo servo = 1; // Servo state
 }
 
-/**
-  * State of the servo installed in the multibeam
-  */
+// State of the servo installed in the multibeam
 message MultibeamServoTel {
   MultibeamServo servo = 1; // Multibeam servo state
 }
 
-/**
-  * GuestPort current readings
-  */
+// GuestPort current readings
 message GuestPortCurrentTel {
   GuestPortCurrent current = 1;
 }
 
-/**
-  * Calibrated IMU data
-  */
+// Calibrated IMU data
 message CalibratedImuTel {
   Imu imu = 1;
 }
 
-/**
-  * Raw IMU data from IMU 1
-  */
+// Raw IMU data from IMU 1
 message Imu1Tel {
   Imu imu = 1;
 }
 
-/**
-  * Raw IMU data from IMU 2
-  */
+// Raw IMU data from IMU 2
 message Imu2Tel {
   Imu imu = 1;
 }
 
-/**
-  * Medusa gamma ray sensor spectrometer data
-  */
+// Medusa gamma ray sensor spectrometer data
 message MedusaSpectrometerDataTel {
   MedusaSpectrometerData data = 1;
 }


### PR DESCRIPTION
The tool for generating the python API ([gapic-generator-python](https://github.com/googleapis/gapic-generator-python)) does not support the C style (`/** foo bar */`) comments very well so I suggest that we use C++ style comments instead (`// foo bar`)