### PR TITLE
Limit Python update trigger to protocol changes

### DIFF
--- a/.github/workflows/ci-python.yaml
+++ b/.github/workflows/ci-python.yaml
@@ -2,6 +2,10 @@ name: Trigger update in blueye.protocol
 
 on:
   push:
+    paths:
+      - "protobuf_definitions/**"
+      - "tcp_protocol.json"
+      - "udp_protocol.json"
     branches:
       - "master"
 


### PR DESCRIPTION
Unnecessary to push updates to blueye.protocol when only the C#/C++ stuff has been updated.