### PR TITLE
Update CMakeLists and model enum

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,4 +30,3 @@ out
 # Other
 build
 build_imx
-build_*

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ out
 # Other
 build
 build_imx
+build_*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,32 +1,40 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.27)
 project(blueyeprotocol VERSION 3.0.0)
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 include(GNUInstallDirs)
-
-find_package(Protobuf REQUIRED)
-find_package(Python3 COMPONENTS Interpreter REQUIRED)
+find_package(protobuf CONFIG REQUIRED)
 
 file(GLOB ProtoFiles "protobuf_definitions/*.proto")
-PROTOBUF_GENERATE_CPP(ProtoSources ProtoHeaders ${ProtoFiles})
-protobuf_generate_python(PROTO_PY ${ProtoFiles})
 
-add_library(blueyeprotocol SHARED ${ProtoSources} ${ProtoHeaders})
+add_library(blueyeprotocol SHARED "${ProtoFiles}")
 
-target_link_libraries(blueyeprotocol PUBLIC ${PROTOBUF_LIBRARIES})
-target_include_directories(blueyeprotocol PUBLIC ${PROTOBUF_INCLUDE_DIRS})
+target_link_libraries(blueyeprotocol PUBLIC protobuf::libprotobuf)
+
+target_include_directories(blueyeprotocol PUBLIC PROTOBUF_INCLUDE_DIRS)
+
+protobuf_generate(
+  LANGUAGE cpp
+  TARGET blueyeprotocol
+  IMPORT_DIRS "${CMAKE_CURRENT_LIST_DIR}/protobuf_definitions"
+  PROTOC_OUT_DIR "${PROTO_BINARY_DIR}"
+  OUT_VAR "ProtoSources"
+)
+
+protobuf_generate(
+  LANGUAGE Python
+  TARGET blueyeprotocol
+  IMPORT_DIRS "${CMAKE_CURRENT_LIST_DIR}/protobuf_definitions"
+  PROTOC_OUT_DIR "${PROTO_BINARY_DIR}")
 
 install(TARGETS blueyeprotocol
   EXPORT blueyeprotocol
   LIBRARY DESTINATION lib)
-install(FILES ${ProtoHeaders} DESTINATION include/blueyeprotocol)
 
-add_custom_target(pyblueyeprotocol
-  DEPENDS ${PROTO_PY})
+# Filter only header files
+list(FILTER ProtoSources INCLUDE REGEX "\\.h$")
 
-install(FILES ${PROTO_PY} DESTINATION ${Python3_SITELIB} OPTIONAL)
-add_custom_target(python_bindings)
-add_dependencies(python_bindings pyblueyeprotocol)
+install(FILES ${ProtoSources} DESTINATION include/blueyeprotocol)
 
 # ---------------------------------------------------------------------------------------
 # Install cmake config
@@ -46,3 +54,31 @@ write_basic_package_version_file(
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/blueyeprotocolConfig.cmake
   ${CMAKE_CURRENT_BINARY_DIR}/blueyeprotocolConfigVersion.cmake
   DESTINATION ${LIB_INSTALL_DIR}/cmake/blueyeprotocol)
+
+# debug
+function(dump_cmake_variables)
+  get_cmake_property(_variableNames VARIABLES)
+  list(SORT _variableNames)
+
+  foreach(_variableName ${_variableNames})
+    if(ARGV0)
+      unset(MATCHED)
+
+      # case sensitive match
+      # string(REGEX MATCH ${ARGV0} MATCHED ${_variableName})
+      #
+      # case insenstitive match
+      string(TOLOWER "${ARGV0}" ARGV0_lower)
+      string(TOLOWER "${_variableName}" _variableName_lower)
+      string(REGEX MATCH ${ARGV0_lower} MATCHED ${_variableName_lower})
+
+      if(NOT MATCHED)
+        continue()
+      endif()
+    endif()
+
+    message(STATUS "${_variableName}=${${_variableName}}")
+  endforeach()
+endfunction()
+
+dump_cmake_variables("ProtoSources")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,40 +1,32 @@
-cmake_minimum_required(VERSION 3.27)
+cmake_minimum_required(VERSION 3.14)
 project(blueyeprotocol VERSION 3.0.0)
 
-set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD 17)
 include(GNUInstallDirs)
-find_package(protobuf CONFIG REQUIRED)
+
+find_package(Protobuf REQUIRED)
+find_package(Python3 COMPONENTS Interpreter REQUIRED)
 
 file(GLOB ProtoFiles "protobuf_definitions/*.proto")
+PROTOBUF_GENERATE_CPP(ProtoSources ProtoHeaders ${ProtoFiles})
+protobuf_generate_python(PROTO_PY ${ProtoFiles})
 
-add_library(blueyeprotocol SHARED "${ProtoFiles}")
+add_library(blueyeprotocol SHARED ${ProtoSources} ${ProtoHeaders})
 
-target_link_libraries(blueyeprotocol PUBLIC protobuf::libprotobuf)
-
-target_include_directories(blueyeprotocol PUBLIC PROTOBUF_INCLUDE_DIRS)
-
-protobuf_generate(
-  LANGUAGE cpp
-  TARGET blueyeprotocol
-  IMPORT_DIRS "${CMAKE_CURRENT_LIST_DIR}/protobuf_definitions"
-  PROTOC_OUT_DIR "${PROTO_BINARY_DIR}"
-  OUT_VAR "ProtoSources"
-)
-
-protobuf_generate(
-  LANGUAGE Python
-  TARGET blueyeprotocol
-  IMPORT_DIRS "${CMAKE_CURRENT_LIST_DIR}/protobuf_definitions"
-  PROTOC_OUT_DIR "${PROTO_BINARY_DIR}")
+target_link_libraries(blueyeprotocol PUBLIC ${PROTOBUF_LIBRARIES})
+target_include_directories(blueyeprotocol PUBLIC ${PROTOBUF_INCLUDE_DIRS})
 
 install(TARGETS blueyeprotocol
   EXPORT blueyeprotocol
   LIBRARY DESTINATION lib)
+install(FILES ${ProtoHeaders} DESTINATION include/blueyeprotocol)
 
-# Filter only header files
-list(FILTER ProtoSources INCLUDE REGEX "\\.h$")
+add_custom_target(pyblueyeprotocol
+  DEPENDS ${PROTO_PY})
 
-install(FILES ${ProtoSources} DESTINATION include/blueyeprotocol)
+install(FILES ${PROTO_PY} DESTINATION ${Python3_SITELIB} OPTIONAL)
+add_custom_target(python_bindings)
+add_dependencies(python_bindings pyblueyeprotocol)
 
 # ---------------------------------------------------------------------------------------
 # Install cmake config
@@ -54,31 +46,3 @@ write_basic_package_version_file(
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/blueyeprotocolConfig.cmake
   ${CMAKE_CURRENT_BINARY_DIR}/blueyeprotocolConfigVersion.cmake
   DESTINATION ${LIB_INSTALL_DIR}/cmake/blueyeprotocol)
-
-# debug
-function(dump_cmake_variables)
-  get_cmake_property(_variableNames VARIABLES)
-  list(SORT _variableNames)
-
-  foreach(_variableName ${_variableNames})
-    if(ARGV0)
-      unset(MATCHED)
-
-      # case sensitive match
-      # string(REGEX MATCH ${ARGV0} MATCHED ${_variableName})
-      #
-      # case insenstitive match
-      string(TOLOWER "${ARGV0}" ARGV0_lower)
-      string(TOLOWER "${_variableName}" _variableName_lower)
-      string(REGEX MATCH ${ARGV0_lower} MATCHED ${_variableName_lower})
-
-      if(NOT MATCHED)
-        continue()
-      endif()
-    endif()
-
-    message(STATUS "${_variableName}=${${_variableName}}")
-  endforeach()
-endfunction()
-
-dump_cmake_variables("ProtoSources")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,8 +12,9 @@ PROTOBUF_GENERATE_CPP(ProtoSources ProtoHeaders ${ProtoFiles})
 protobuf_generate_python(PROTO_PY ${ProtoFiles})
 
 add_library(blueyeprotocol SHARED ${ProtoSources} ${ProtoHeaders})
+find_package(absl REQUIRED CONFIG)
 
-target_link_libraries(blueyeprotocol PUBLIC ${PROTOBUF_LIBRARIES})
+target_link_libraries(blueyeprotocol PUBLIC ${PROTOBUF_LIBRARIES} absl::log_internal_message absl::log_internal_check_op)
 target_include_directories(blueyeprotocol PUBLIC ${PROTOBUF_INCLUDE_DIRS})
 
 install(TARGETS blueyeprotocol

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,9 +12,22 @@ PROTOBUF_GENERATE_CPP(ProtoSources ProtoHeaders ${ProtoFiles})
 protobuf_generate_python(PROTO_PY ${ProtoFiles})
 
 add_library(blueyeprotocol SHARED ${ProtoSources} ${ProtoHeaders})
-find_package(absl REQUIRED CONFIG)
 
-target_link_libraries(blueyeprotocol PUBLIC ${PROTOBUF_LIBRARIES} absl::log_internal_message absl::log_internal_check_op)
+set(EXT_LIBS
+  ${PROTOBUF_LIBRARIES}
+)
+
+# For protobuf linking. Should rather user find_package(protobuf CONFIG REQUIRED) but that fails in yocto
+find_package(absl QUIET)
+
+if(absl_FOUND)
+  list(APPEND EXT_LIBS
+    absl::log_internal_message
+    absl::log_internal_check_op
+  )
+endif()
+
+target_link_libraries(blueyeprotocol PUBLIC ${EXT_LIBS})
 target_include_directories(blueyeprotocol PUBLIC ${PROTOBUF_INCLUDE_DIRS})
 
 install(TARGETS blueyeprotocol

--- a/cmake/blueyeprotocolConfig.cmake.in
+++ b/cmake/blueyeprotocolConfig.cmake.in
@@ -5,3 +5,9 @@ set_and_check(blueyeprotocol_INCLUDE_DIRS "@PACKAGE_INCLUDE_INSTALL_DIR@")
 set_and_check(blueyeprotocol_LIB_DIR "@PACKAGE_LIB_INSTALL_DIR@")
 set_and_check(blueyeprotocol_LIB_DIRS "@PACKAGE_LIB_INSTALL_DIR@")
 set(blueyeprotocol_LIBRARIES blueyeprotocol)
+
+find_package(absl QUIET)
+
+if(absl_FOUND)
+    link_libraries(absl::log_internal_message absl::log_internal_check_op)
+endif()

--- a/protobuf_definitions/message_formats.proto
+++ b/protobuf_definitions/message_formats.proto
@@ -436,6 +436,7 @@ enum Model {
   MODEL_PRO = 2; // Blueye Pro, features camera tilt
   MODEL_X1 = 4; // Blueye X1, features camera tilt and one guest port
   MODEL_X3 = 3; // Blueye X3, features support for peripherals
+  MODEL_X3_ULTRA = 6; // Blueye X3 Ultra
   MODEL_NEXT = 5; // Blueye ?
 }
 


### PR DESCRIPTION
Newer protobuf versions use the `abseil` library. While protobuf's own cmake files detect the correct libraries to link to, cmake's FindProtobuf is not aware of the new dependency. Using protobuf's own cmake files would be the cleaner way to do it, however, yocto seems to be confused between the host and target dependencies, therefore, we use for now a workaround.