### PR TITLE
Add time-lapse state tel message

### DIFF
--- a/protobuf_definitions/message_formats.proto
+++ b/protobuf_definitions/message_formats.proto
@@ -148,6 +148,20 @@ message RecordState {
   int32 guestport_seconds = 4; // Guestport record time (s)
 }
 
+// Interval type for time-lapse photos.
+enum IntervalType {
+  INTERVAL_TYPE_UNSPECIFIED = 0; // Unspecified
+  INTERVAL_TYPE_TIME = 1; // Time interval
+  INTERVAL_TYPE_DISTANCE = 2; // Distance interval
+}
+
+// Time-lapse state published if time-lapse mission is running.
+message TimeLapseState {
+  float interval = 1; // Interval between photos
+  int32 photos_taken = 2; // Number of photos taken
+  IntervalType interval_type = 3; // Interval type for photos, distance or time
+}
+
 // Water density.
 //
 // Used to specify the water density the drone is operating in,

--- a/protobuf_definitions/telemetry.proto
+++ b/protobuf_definitions/telemetry.proto
@@ -89,6 +89,11 @@ message RecordStateTel {
   RecordState record_state = 1;
 }
 
+// Time-lapse state from the drone.
+message TimeLapseStateTel {
+  TimeLapseState time_lapse_state = 1;
+}
+
 // Receive essential information about the battery status.
 message BatteryTel {
   Battery battery = 1; // Essential battery information.


### PR DESCRIPTION
We need a way to communicate if the drone is in time-laps mode. This message can then be used to communicate number of photos taken, and what interval that is expected, in meters or seconds.