### PR TITLE
Add StartDiveCtrl and EndDiveCtrl messages

### DIFF
--- a/Blueye.Protocol.Protobuf.csproj
+++ b/Blueye.Protocol.Protobuf.csproj
@@ -5,7 +5,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <LangVersion>8.0</LangVersion>
     <PackageId>Blueye.Protocol.Protobuf</PackageId>
-    <VersionPrefix>4.3.0</VersionPrefix>
+    <VersionPrefix>4.4.0</VersionPrefix>
     <Company>Blueye Robotics AS</Company>
     <ProduceReferenceAssembly>True</ProduceReferenceAssembly>
     <PackageDescription>Library with dotnet representation of the ProtocolDefinition protobuf files.</PackageDescription>

--- a/protobuf_definitions/control.proto
+++ b/protobuf_definitions/control.proto
@@ -201,3 +201,17 @@ message ActivateMultibeamCtrl {
 // Deactivate multibeam
 message DeactivateMultibeamCtrl {
 }
+
+// Message sent when the user hits the start dive button in the app.
+//
+// The message does not do anything, but is included in the log files so we can see
+// at which point the user entered the dive view.
+message StartDiveCtrl {
+}
+
+// Message sent when the user hits the end dive button in the app.
+//
+// The message does not do anything, but is included in the log files so we can see
+// at which point the user exited the dive view.
+message EndDiveCtrl {
+}


### PR DESCRIPTION
These messages will be used to:

- Log when the user enters and exits the dive view
- Could potentially be used to split a dive log into smaller logs for each start-end dive pair