### PR TITLE
Remove optional modifier (deprecated in Proto3 syntax)

### DIFF
--- a/protobuf_definitions/message_formats.proto
+++ b/protobuf_definitions/message_formats.proto
@@ -974,7 +974,7 @@ message MultibeamPing {
 
   bytes ping_data = 10; // Ping data (row major, 2D, grayscale image)
   GuestPortDeviceID device_id = 11; // Device ID of the sonar
-  optional google.protobuf.Timestamp frame_generation_timestamp = 12; // Timestamp when the frame was generated
+  google.protobuf.Timestamp frame_generation_timestamp = 12; // Timestamp when the frame was generated
 }
 
 


### PR DESCRIPTION
Closes https://github.com/BluEye-Robotics/ProtocolDefinitions/issues/164