### PR TITLE
New DVL error flags and notifications

### DIFF
--- a/protobuf_definitions/message_formats.proto
+++ b/protobuf_definitions/message_formats.proto
@@ -475,6 +475,8 @@ enum NotificationType {
   NOTIFICATION_TYPE_SET_TILT_MAIN_CAMERA = 28; // Set tilt for main camera
   NOTIFICATION_TYPE_SET_TILT_MULTIBEAM = 29; // Set tilt for multibeam
   NOTIFICATION_TYPE_INSTRUCTION_SKIPPED = 30; // When an instruction is not available in the ROV
+  NOTIFICATION_TYPE_DVL_HIGH_TEMPERATURE_DETECTED = 31; // DVL high temperature detected
+  NOTIFICATION_TYPE_DVL_THERMAL_PROTECTION_MODE_DETECTED = 32; // DVL thermal protection mode detected
 }
 
 // List of available notification levels.
@@ -657,6 +659,8 @@ message ErrorFlags {
   bool gp2_bat_current = 40;  // Max battery current exceeded on GP2
   bool gp3_bat_current = 41;  // Max battery current exceeded on GP3
   bool gp_20v_current = 42;  // Max 20V current exceeded on GP
+  bool dvl_thermal_protection_mode = 43;  // DVL is in thermal protection mode
+  bool dvl_no_power_since_boot = 44;  // GP protection has been triggered at boot or faulty DVL
 }
 
 // Available camera resolutions.

--- a/protobuf_definitions/message_formats.proto
+++ b/protobuf_definitions/message_formats.proto
@@ -660,7 +660,7 @@ message ErrorFlags {
   bool gp3_bat_current = 41;  // Max battery current exceeded on GP3
   bool gp_20v_current = 42;  // Max 20V current exceeded on GP
   bool dvl_thermal_protection_mode = 43;  // DVL is in thermal protection mode
-  bool dvl_no_power_since_boot = 44;  // GP protection has been triggered at boot or faulty DVL
+  bool dvl_no_power = 44;  // GP protection has been triggered at boot or faulty DVL
 }
 
 // Available camera resolutions.


### PR DESCRIPTION
This PR adds new Errorflags for the DVL.
- Thermal protection mode. When the DVL has issued the Heat warning, we assume that it powered off due to the heat protection afterwards.
- No power mode. This reflects the GP protection at boot issue.

Also two new Notifications are added to warn the user:
- NOTIFICATION_TYPE_DVL_HIGH_TEMPERATURE_DETECTED
- NOTIFICATION_TYPE_DVL_IS_IN_HEAT_PROTECTION_MODE