### PR TITLE
Add queue load

### DIFF
--- a/protobuf_definitions/message_formats.proto
+++ b/protobuf_definitions/message_formats.proto
@@ -1065,4 +1065,6 @@ message PersistentStorageSettings {
 message CPUInfo {
   float cpu_load = 1; // CPU load (0..1)
   float memory_bus_load = 2; // Memory bus load (0..1)
+  float main_queue_load = 3; // Main queue load (0..1)
+  float guestport_queue_load = 4 ; // Guestport queue load (0..1)
 }

--- a/protobuf_definitions/telemetry.proto
+++ b/protobuf_definitions/telemetry.proto
@@ -277,6 +277,7 @@ message MultibeamDiscoveryTel {
   MultibeamDiscovery discovery = 1; // Discovery data from a multibeam sonar
 }
 
+// Information about cpu and memory usage
 message CPUInfoTel {
   CPUInfo cpu_info = 1;
 }


### PR DESCRIPTION
Alternatively, we could rename it to `SystemInfoTel` or `PerformanceTel` before it's added to master.