### PR TITLE
Add hardware_supported error flag

### DIFF
--- a/protobuf_definitions/message_formats.proto
+++ b/protobuf_definitions/message_formats.proto
@@ -699,6 +699,7 @@ message ErrorFlags {
   bool dvl_no_power = 44;  // GP protection has been triggered at boot or faulty DVL.
   bool usb_disconnect = 45; // USB disconnect.
   bool video_urb_error = 46;  // Video URB error.
+  bool hardware_supported = 47;  // Hardware supported on current blunux version.
 }
 
 // Available camera resolutions.

--- a/protobuf_definitions/message_formats.proto
+++ b/protobuf_definitions/message_formats.proto
@@ -699,7 +699,7 @@ message ErrorFlags {
   bool dvl_no_power = 44;  // GP protection has been triggered at boot or faulty DVL.
   bool usb_disconnect = 45; // USB disconnect.
   bool video_urb_error = 46;  // Video URB error.
-  bool hardware_supported = 47;  // Hardware supported on current blunux version.
+  bool hardware_not_supported = 47;  // Hardware not supported on current blunux version.
 }
 
 // Available camera resolutions.


### PR DESCRIPTION
This flag show whether the current version of blunux supports the HW version of the BB and the MB. 

Related to https://github.com/BluEye-Robotics/libblunux/issues/226