### PR TITLE
Add SetHeadingMode Req

### DIFF
--- a/protobuf_definitions/req_rep.proto
+++ b/protobuf_definitions/req_rep.proto
@@ -149,7 +149,7 @@ message SetInstructionUpdateReq {
 message SetInstructionUpdateRep {
 }
 
-// Set heading mode used in dead reckoning.
+// Set the heading mode used in dead reckoning.
 message SetHeadingModeReq {
   HeadingMode heading_mode = 1; // The heading mode to set.
 }

--- a/protobuf_definitions/req_rep.proto
+++ b/protobuf_definitions/req_rep.proto
@@ -149,6 +149,11 @@ message SetInstructionUpdateReq {
 message SetInstructionUpdateRep {
 }
 
+// Set heading mode used in dead reckoning.
+message SetHeadingModeReq {
+  HeadingMode heading_mode = 1; // The heading mode to set.
+}
+
 // Request to update the publish frequency
 message SetPubFrequencyReq {
   string message_type = 1; // Message name, f. ex. "AttitudeTel"


### PR DESCRIPTION
Sets the heading mode to use in dead reckoning. This is added so the app can set the desired mode on connect. This can also be used later with the GyroOnly data in the heading bar.