### PR TITLE
Add MagneticDeclination msg definition

### DIFF
--- a/protobuf_definitions/message_formats.proto
+++ b/protobuf_definitions/message_formats.proto
@@ -376,6 +376,20 @@ message Attitude {
   float yaw = 3; // Yaw angle (-180°..180°).
 }
 
+// Location source used in magnetic declination look-up.
+enum LocationSource {
+  LOCATION_SOURCE_UNSPECIFIED = 0; // The position is not set.
+  LOCATION_SOURCE_USER = 1; // Typically pilot device GPS.
+  LOCATION_SOURCE_DRONE = 2; // Blueye GPS, DVL, or a USBL system.
+}
+
+// The Magnetic Declination status used to get true North compass readings based on location.
+message MagneticDeclination {
+  LocationSource location_source = 1; // Location source used for the magnetic declination look-up in geographiclib.
+  float declination = 2; // The declination which is applied to the yaw field in the Attitude msg.
+  LatLongPosition location = 3; // The location used for the magnetic declination look-up.
+}
+
 // Drone altitude over seabed, typically obtained from a DVL.
 message Altitude {
   float value = 1; // Drone altitude over seabed (m).

--- a/protobuf_definitions/telemetry.proto
+++ b/protobuf_definitions/telemetry.proto
@@ -14,6 +14,11 @@ message AttitudeTel {
   Attitude attitude = 1; // The attitude of the drone.
 }
 
+// Current Magnetic Declination status. Used to get true North compass readings based on location.
+message MagneticDeclinationTel {
+  MagneticDeclination magnetic_declination = 1; // The current magnetic declination status of the drone.
+}
+
 // Receive the current altitude of the drone.
 message AltitudeTel {
   Altitude altitude = 1; // The altitude of the drone.


### PR DESCRIPTION
The MagneticDeclination message is used to broadcast the current magnetic declination status to the app, SDK, and log file.

This way one can know if the compass is true North or not. The message is published at a lower rate since it is slowly changing.