### PR TITLE
add Cerulean Tracker 650 device ID

### DIFF
--- a/protobuf_definitions/message_formats.proto
+++ b/protobuf_definitions/message_formats.proto
@@ -881,7 +881,7 @@ enum GuestPortDeviceID {
   GUEST_PORT_DEVICE_ID_BLUEPRINT_SUBSEA_OCULUS_C550D = 41; // Blueprint Subsea Oculus C550d.
   GUEST_PORT_DEVICE_ID_BLUEPRINT_SUBSEA_OCULUS_M370S = 42; // Blueprint Subsea Oculus M370s.
   GUEST_PORT_DEVICE_ID_WATERLINKED_SONAR_3D15 = 43; // Waterlinked Sonar 3D-15.
-  GUEST_PORT_DEVICE_ID_CERULEAN_TRACKER_650 = 44; // Cerulean Tracker 650. 
+  GUEST_PORT_DEVICE_ID_CERULEAN_TRACKER_650 = 44; // Cerulean Tracker 650.
 }
 
 // Guest port number.
@@ -900,6 +900,7 @@ enum NavigationSensorID {
   NAVIGATION_SENSOR_ID_NMEA = 3; // NMEA stream from external positioning system.
   NAVIGATION_SENSOR_ID_BLUEYE_GNSS = 4; // Blueye GNSS device on the ROV.
   NAVIGATION_SENSOR_ID_NORTEK_DVL_NUCLEUS = 5; // Nortek DVL Nucleus 1000.
+  NAVIGATION_SENSOR_ID_CERULEAN_TRACKER_650 = 6; // Cerulean Tracker 650.
 }
 
 // Navigation sensor used in the position observer with validity state.


### PR DESCRIPTION
This will add the Cerulean Tracker 650 as part of the definitions. 