### PR TITLE
Add message definitions for removable storage device

### DIFF
--- a/protobuf_definitions/control.proto
+++ b/protobuf_definitions/control.proto
@@ -215,3 +215,12 @@ message StartDiveCtrl {
 // at which point the user exited the dive view.
 message EndDiveCtrl {
 }
+
+// Message sent when the user wants to format a connected removable storage device.
+//
+// The app will receive a RemovableStorageTel message with information about the newly formatted drive.
+//
+// Warning: The drone will delete any partitions and format the drive with a single exFat partition.
+// Any data on the drive will be lost.
+message FormatRemovableStorageDeviceCtrl {
+}

--- a/protobuf_definitions/message_formats.proto
+++ b/protobuf_definitions/message_formats.proto
@@ -583,6 +583,8 @@ message StorageSpace {
   int64 free_space = 2; // Available bytes of storage space (B).
 }
 
+  bool wrong_file_system_found = 4; // The wrong file system is found.
+  bool device_is_read_only = 5; // The device is in read-only mode.
 // Compass calibration state.
 message CalibrationState {
 

--- a/protobuf_definitions/message_formats.proto
+++ b/protobuf_definitions/message_formats.proto
@@ -583,14 +583,48 @@ message StorageSpace {
   int64 free_space = 2; // Available bytes of storage space (B).
 }
 
+// Storage partition.
+message StoragePartition {
+  StorageSpace storage_space = 1; // The amount of storage space on the device.
+  string file_system_type = 2; // File system type of the removable storage device.
+  string device_path = 3; // Partition device path
+  string mount_path = 4; // Mount path of the partition.
+}
+
+// Removable storage device.
+message RemovableStorageDevice {
+  // Overall status of the storage device.
+  enum Status {
+    STATUS_UNSPECIFIED = 0; // Unspecified.
+    STATUS_READY = 1; // The storage device is valid and ready for use.
+    STATUS_FORMATTING = 2; // The storage device is being formatted
+    STATUS_ERROR = 3; // The storage device is in an error state.
+  }
+  string vendor_name = 1; // USB vendor name.
+  string model_name = 2; // Model name of the USB storage device.
+  string device_path = 3; // Mount path of the storage device.
+  Status status = 4; // Status of the storage device.
+  RemovableStorageErrorFlags error_flags = 5; // Any active error flags for the storage device.
+  repeated StoragePartition partitions = 6; // List of partitions on the storage device.
+}
+
+// Error flags related to a removable storage device.
+message RemovableStorageErrorFlags {
+  // Optional error message to give additional information from the drone to a client about active error flags.
+  string error_message = 1;
+  bool no_partitions_found = 2; // Device is attached but no partitions are found.
+  bool multiple_partitions_found = 3; // Multiple partitions are found.
   bool wrong_file_system_found = 4; // The wrong file system is found.
   bool device_is_read_only = 5; // The device is in read-only mode.
+  bool formatting_failed = 6; // Formatting of the device failed.
+}
+
 // Compass calibration state.
 message CalibrationState {
 
   // Status of the compass calibration procedure.
   //
-  // When calibration is started, the status will indicate the active (upfacing) axis.
+  // When calibration is started, the status will indicate the active (up facing) axis.
   enum Status
   {
     STATUS_UNSPECIFIED = 0; // Unspecified status.
@@ -602,7 +636,7 @@ message CalibrationState {
     STATUS_CALIBRATING_Y_NEGATIVE = 6; // Compass is calibrating and the negative Y axis is active.
     STATUS_CALIBRATING_Z_POSITIVE = 7; // Compass is calibrating and the positive Z axis is active.
     STATUS_CALIBRATING_Z_NEGATIVE = 8; // Compass is calibrating and the negative Z axis is active.
-    STATUS_CALIBRATING_THRUSTER = 9; // Compass is calibrating for thruster interferance.
+    STATUS_CALIBRATING_THRUSTER = 9; // Compass is calibrating for thruster interference.
   }
 
   Status status = 1; // Current calibration status.

--- a/protobuf_definitions/telemetry.proto
+++ b/protobuf_definitions/telemetry.proto
@@ -148,7 +148,13 @@ message CanisterBottomHumidityTel {
 
 // Video storage info.
 message VideoStorageSpaceTel {
-  StorageSpace storage_space = 1; // Video storage information.
+  StorageSpace storage_space = 1; // Internal Video storage information.
+  StorageSpace removable_space = 2; // Removable Video storage information. Can be empty.
+}
+
+// Information about removable storage device.
+message RemovableStorageTel {
+  RemovableStorageDevice storage_device = 1; // Information about the storage device (such as partitions)
 }
 
 // Data storage info.


### PR DESCRIPTION
Adds new message definitions for use with the new removable storage device.

The key improvements are:

- `RemovableStorageTel` with information about any connected removable storage device
- `FormatRemovableStorageDeviceCtrl` to format a storage device
- `RemovableStorageErrorFlags` listing all the relevant error states for the device
- `GuestPortDetachStatus` is used to indicate weather a removable storage device is connected to the USB cable (when the water proof canister is attached, and a user optionally can have a USB storage device inside the canister).