### PR TITLE
Add installation step for *.proto files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,7 @@ install(TARGETS blueyeprotocol
   EXPORT blueyeprotocol
   LIBRARY DESTINATION lib)
 install(FILES ${ProtoHeaders} DESTINATION include/blueyeprotocol)
+install(FILES ${ProtoFiles} DESTINATION include/blueyeprotocol/protobuf)
 
 add_custom_target(pyblueyeprotocol
   DEPENDS ${PROTO_PY})


### PR DESCRIPTION
The new `ZMQSubscriber` and `ZMQRepliers` in libblunux require a `typevals{}` list to generate some code at compile time (https://github.com/BluEye-Robotics/libblunux/pull/255). It looks something like:

```cpp
namespace blunux::zmq {
constexpr inline auto rep_messages =
    utils::typevals{} +
    utils::type_wrapper_2<blueye::protocol::SetOverlayParametersReq,
                          blueye::protocol::SetOverlayParametersRep>{} +
    utils::type_wrapper_2<blueye::protocol::GetOverlayParametersReq,
                          blueye::protocol::GetOverlayParametersRep>{} +
    utils::type_wrapper_2<blueye::protocol::SetCameraParametersReq,
                          blueye::protocol::SetCameraParametersRep>{} +
    utils::type_wrapper_2<blueye::protocol::GetCameraParametersReq,
                          blueye::protocol::GetCameraParametersRep>{} +
    utils::type_wrapper_2<blueye::protocol::SyncTimeReq,
                          blueye::protocol::SyncTimeRep>{} + ...
```

Managing these lists manually will be a little cumbersome, so I've written a script in `libblunux` that auto-generates that code based on the .proto files. To make sure we always have them in a consistent location I thought it best to include them in the headers. 

The protobuf library itself also does this, installing files like:
- /usr/include/google/protobuf/any.proto
- /usr/include/google/protobuf/field_mask.proto
- /usr/include/google/protobuf/wrappers.proto
- /usr/include/google/protobuf/api.proto
- /usr/include/google/protobuf/descriptor.proto
- /usr/include/google/protobuf/duration.proto
- /usr/include/google/protobuf/source_context.proto
- /usr/include/google/protobuf/struct.proto
- /usr/include/google/protobuf/timestamp.proto
- /usr/include/google/protobuf/empty.proto
- /usr/include/google/protobuf/type.proto

Same with other libraries using protobuf.

They install to the the path `.../include/blueyeprotocol/protobuf/*.proto`