### PR TITLE
Add events queue load for node_comm

### DIFF
--- a/protobuf_definitions/message_formats.proto
+++ b/protobuf_definitions/message_formats.proto
@@ -1221,4 +1221,5 @@ message CPUInfo {
   float memory_bus_load = 2; // Memory bus load (0..1).
   float main_queue_load = 3; // Main queue load (0..1).
   float guestport_queue_load = 4 ; // Guestport queue load (0..1).
+  float comm_queue_load = 5; // Communication queue load (0..1).
 }


### PR DESCRIPTION
Since node_comm will be a proper ROS node with an EventsExecutor, I'm taking the liberty of adding the queue load for node_comm to the CPUInfo.