### PR TITLE
Add message definition for Surface Unit

### DIFF
--- a/protobuf_definitions/message_formats.proto
+++ b/protobuf_definitions/message_formats.proto
@@ -1228,7 +1228,7 @@ message CPUInfo {
 //
 // This message is published by the Surface Unit, and re-published by
 // the drone over the communication protocol.
-message SurfaceUnitBattery {
+message SurfaceUnitBatteryInfo {
   enum ChargeStatus {
     CHARGE_STATUS_UNSPECIFIED = 0;
     CHARGE_STATUS_DISCHARGE = 1;

--- a/protobuf_definitions/message_formats.proto
+++ b/protobuf_definitions/message_formats.proto
@@ -1244,5 +1244,5 @@ message SurfaceUnitBattery {
 // This message is published by the Surface Unit, and re-published by
 // the drone over the communication protocol.
 message SurfaceUnitVersionInfo {
-  string required_blunux_version = 1; // Surface Unit firmware version (x.y.z).
+  string firmware_version = 1; // Surface Unit firmware version (x.y.z).
 }

--- a/protobuf_definitions/message_formats.proto
+++ b/protobuf_definitions/message_formats.proto
@@ -1244,5 +1244,5 @@ message SurfaceUnitBattery {
 // This message is published by the Surface Unit, and re-published by
 // the drone over the communication protocol.
 message SurfaceUnitVersionInfo {
-  string firmware_version = 1; // Surface Unit firmware version (x.y.z).
+  string version = 1; // Surface Unit firmware version (x.y.z).
 }

--- a/protobuf_definitions/message_formats.proto
+++ b/protobuf_definitions/message_formats.proto
@@ -1223,3 +1223,26 @@ message CPUInfo {
   float guestport_queue_load = 4 ; // Guestport queue load (0..1).
   float comm_queue_load = 5; // Communication queue load (0..1).
 }
+
+// Surface Unit battery information.
+//
+// This message is published by the Surface Unit, and re-published by
+// the drone over the communication protocol.
+message SurfaceUnitBattery {
+  enum ChargeStatus {
+    CHARGE_STATUS_UNSPECIFIED = 0;
+    CHARGE_STATUS_DISCHARGE = 1;
+    CHARGE_STATUS_CHARGE = 2;
+    CHARGE_STATUS_CHARGE_ERROR = 3;
+  }
+  ChargeStatus status = 1; // Battery charge status.
+  float level = 2; // Battery level (0..1). 
+}
+
+// Surface Unit version information.
+//
+// This message is published by the Surface Unit, and re-published by
+// the drone over the communication protocol.
+message SurfaceUnitVersionInfo {
+  string required_blunux_version = 1; // Surface Unit firmware version (x.y.z).
+}

--- a/protobuf_definitions/telemetry.proto
+++ b/protobuf_definitions/telemetry.proto
@@ -287,3 +287,9 @@ message MultibeamDiscoveryTel {
 message CPUInfoTel {
   CPUInfo cpu_info = 1; // CPU information.
 }
+
+// Surface Unit telemetry message.
+message SurfaceUnitTel {
+  SurfaceUnitBatteryTel battery_info = 1; // Battery information.
+  SurfaceUnitVersionInfo version_info = 2; // Version information.
+}

--- a/protobuf_definitions/telemetry.proto
+++ b/protobuf_definitions/telemetry.proto
@@ -290,6 +290,6 @@ message CPUInfoTel {
 
 // Surface Unit telemetry message.
 message SurfaceUnitTel {
-  SurfaceUnitBatteryTel battery_info = 1; // Battery information.
+  SurfaceUnitBatteryInfo battery_info = 1; // Battery information.
   SurfaceUnitVersionInfo version_info = 2; // Version information.
 }


### PR DESCRIPTION
Closing #215 by adding message definitions for the Surface Unit messages.

Version number published as string (instead of minor, major, patch) for consistency with other version numbers in the protocol.