### PR TITLE
Add streaming protocol, also fix comment length

### DIFF
--- a/protobuf_definitions/message_formats.proto
+++ b/protobuf_definitions/message_formats.proto
@@ -787,11 +787,11 @@ message ErrorFlags {
 // Available camera resolutions.
 enum Resolution {
   RESOLUTION_UNSPECIFIED = 0; // Resolution not specified.
-  RESOLUTION_VGA = 4; // VGA resolution (640x480).
-  RESOLUTION_SVGA = 5; // SVGA resolution (800x600).
-  RESOLUTION_HD_720P = 2; // 720p HD resolution.
-  RESOLUTION_FULLHD_1080P = 1; // 1080p Full HD resolution.
-  RESOLUTION_UHD_4K = 3; // 4K Ultra HD resolution.
+  RESOLUTION_VGA = 4; // VGA (640x480).
+  RESOLUTION_SVGA = 5; // SVGA (800x600).
+  RESOLUTION_HD_720P = 2; // 720p HD (1280x720).
+  RESOLUTION_FULLHD_1080P = 1; // 1080p Full HD (1920x1080).
+  RESOLUTION_UHD_4K = 3; // 4K Ultra HD (3840x2160).
 }
 
 // Available camera frame rates.


### PR DESCRIPTION
We discussed having a different message for this, but the protocol is similar to resolution and framerate in how and how often it is changed, so I think this is the right place.

Using an enum allows us to add other protocols in the future.

Additionally, VGA and SVGA resolutions are added.

Also fixes linting which I overlooked in a previous PR.