### PR TITLE
Add parameter to specify storage location

### DIFF
--- a/protobuf_definitions/control.proto
+++ b/protobuf_definitions/control.proto
@@ -50,10 +50,12 @@ message WatchdogCtrl {
 // Issue a command to start video recording.
 message RecordCtrl {
   RecordOn record_on = 1; // Message specifying which cameras to record.
+  StorageLocation storage_location = 2; // Storage location to use for the recordings.
 }
 
 // Issue a command to take a picture.
 message TakePictureCtrl {
+  StorageLocation storage_location = 1; // Storage location to use for the picture.
 }
 
 // Issue a command to start compass calibration.

--- a/protobuf_definitions/control.proto
+++ b/protobuf_definitions/control.proto
@@ -47,7 +47,7 @@ message WatchdogCtrl {
   uint32 client_id = 2; // The ID of the client, received in the ConnectClientRep response.
 }
 
-// Issue a command to start video recording.
+// Issue a command to start video or multibeam recording.
 message RecordCtrl {
   RecordOn record_on = 1; // Message specifying which cameras to record.
   StorageLocation storage_location = 2; // Storage location to use for the recordings.

--- a/protobuf_definitions/message_formats.proto
+++ b/protobuf_definitions/message_formats.proto
@@ -592,7 +592,7 @@ message DiveTime {
   int32 value = 1; // Number of seconds the drone has been submerged.
 }
 
-// Which cameras are supposed to be recording.
+// Which cameras or multibeam are supposed to be recording.
 message RecordOn {
   bool main = 1; // Record the main camera.
   bool guestport = 2; // Record external camera.

--- a/protobuf_definitions/message_formats.proto
+++ b/protobuf_definitions/message_formats.proto
@@ -599,6 +599,15 @@ message RecordOn {
   bool multibeam = 3; // Record multibeam.
 }
 
+// Storage location.
+//
+// Used to specify which storage location to use for recording photos and videos.
+enum StorageLocation {
+  STORAGE_LOCATION_UNSPECIFIED = 0; // Unspecified.
+  STORAGE_LOCATION_INTERNAL = 1; // Internal storage of the drone.
+  STORAGE_LOCATION_REMOVABLE = 2; // Removable storage device.
+}
+
 // Storage space.
 message StorageSpace {
   int64 total_space = 1; // Total bytes of storage space (B).
@@ -813,7 +822,6 @@ enum StreamingProtocol {
   STREAMING_PROTOCOL_RTSP_H264 = 1; // RTSP streaming protocol using H264 codec.
   STREAMING_PROTOCOL_RTSP_MJPEG = 2; // RTSP streaming protocol using MJPEG codec.
 }
-
 
 // Camera parameters.
 message CameraParameters {


### PR DESCRIPTION
Allows the client to specify if a media file should be stored on internal or external storage (if available).