### PR TITLE
Remove SVGA, rename VGA

### DIFF
--- a/protobuf_definitions/message_formats.proto
+++ b/protobuf_definitions/message_formats.proto
@@ -796,8 +796,7 @@ message ErrorFlags {
 // Available camera resolutions.
 enum Resolution {
   RESOLUTION_UNSPECIFIED = 0; // Resolution not specified.
-  RESOLUTION_VGA = 4; // VGA (640x480).
-  RESOLUTION_SVGA = 5; // SVGA (800x600).
+  RESOLUTION_VGA_480P = 4; // VGA (640x480).
   RESOLUTION_HD_720P = 2; // 720p HD (1280x720).
   RESOLUTION_FULLHD_1080P = 1; // 1080p Full HD (1920x1080).
   RESOLUTION_UHD_4K = 3; // 4K Ultra HD (3840x2160).


### PR DESCRIPTION
Added `_480P` postfix and removed SVGA.

I didn't add 5 to the reserved list since it's not actively in use yet.