### PR TITLE
Add OperatorInfo message to track dive operator

### DIFF
--- a/protobuf_definitions/control.proto
+++ b/protobuf_definitions/control.proto
@@ -209,6 +209,7 @@ message DeactivateMultibeamCtrl {
 // The message does not do anything, but is included in the log files so we can see
 // at which point the user entered the dive view.
 message StartDiveCtrl {
+  OperatorInfo operator = 1; // Optional information about the operator who started the dive.
 }
 
 // Message sent when the user hits the end dive button in the app.

--- a/protobuf_definitions/control.proto
+++ b/protobuf_definitions/control.proto
@@ -209,7 +209,7 @@ message DeactivateMultibeamCtrl {
 // The message does not do anything, but is included in the log files so we can see
 // at which point the user entered the dive view.
 message StartDiveCtrl {
-  OperatorInfo operator = 1; // Optional information about the operator who started the dive.
+  OperatorInfo operator_info = 1; // Optional information about the operator who started the dive.
 }
 
 // Message sent when the user hits the end dive button in the app.

--- a/protobuf_definitions/message_formats.proto
+++ b/protobuf_definitions/message_formats.proto
@@ -1360,3 +1360,12 @@ message CameraPanTiltZoom {
   float tilt = 2; // Vertical tilt (-1.0..1.0), where 0.0 is center.
   float zoom = 3; // Zoom level (0.0..1.0), where 0.0 is no zoom and 1.0 is maximum zoom.
 }
+
+// Information about the operator controlling the drone.
+//
+// Used to identify who started a dive, for reporting and when importing
+// dives to Blueye Cloud.
+message OperatorInfo {
+  string name = 1; // Full name of the operator.
+  string email = 2; // E-mail address of the operator.
+}


### PR DESCRIPTION
## Summary

- Adds a new `OperatorInfo` message in `message_formats.proto` with `name` and `email` fields to identify the operator controlling the drone.
- Adds an optional `operator` field to `StartDiveCtrl` in `control.proto`, so dive logs capture who started each dive.
- Enables downstream use in reporting and when importing dives to Blueye Cloud.

## Test plan

- [ ] Verify proto files compile successfully (CI protolint + builds)
- [ ] Confirm existing clients without operator info still work (field is optional in proto3)
- [ ] Verify the new message appears in generated TypeScript, C#, and Python libraries

🤖 Generated with [Claude Code](https://claude.com/claude-code)