### PR TITLE
Use trusted publisher for npm workflow

### DIFF
--- a/.github/workflows/ci-typescript.yaml
+++ b/.github/workflows/ci-typescript.yaml
@@ -5,27 +5,30 @@ on:
     branches:
       - master
 
+permissions:
+  id-token: write # Required for OIDC
+  contents: read
+
 jobs:
   compile:
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
         with:
           version: 10
           run_install: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: "latest"
+          node-version: "24"
           cache: "pnpm"
-          registry-url: "https://registry.npmjs.org/"
-          scope: "@blueyerobotics"
+          cache-dependency-path: pnpm-lock.yaml
 
       - name: Install dependencies
         run: |
@@ -54,5 +57,3 @@ jobs:
           SHORT_SHA=${GITHUB_SHA::8}
           pnpm version --no-git-tag-version "${VERSION}-${SHORT_SHA}"
           pnpm publish --no-git-checks --access public --tag latest
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Same thing we do for our other npm packages so we don't need to maintain or generate new npm tokens.