### PR TITLE
feat: add image dimensions to ObjectDetections message

### DIFF
--- a/protobuf_definitions/message_formats.proto
+++ b/protobuf_definitions/message_formats.proto
@@ -1428,6 +1428,8 @@ message ObjectDetection {
 message ObjectDetections {
   repeated ObjectDetection detections = 1; // List of detections in the frame.
   Camera camera = 2; // Which camera the detections are from.
+  uint32 image_width = 3; // Width of the source image (px).
+  uint32 image_height = 4; // Height of the source image (px).
 }
 
 // Generic filter settings.


### PR DESCRIPTION
## Summary

Add `image_width` and `image_height` fields to the `ObjectDetections` protobuf message.

## Changes

```protobuf
message ObjectDetections {
  repeated ObjectDetection detections = 1;
  Camera camera = 2;
  uint32 image_width = 3;  // NEW
  uint32 image_height = 4; // NEW
}
```

## Motivation

Bounding box coordinates in `ObjectDetection` are in pixels, but without the source image dimensions consumers cannot normalize or interpret them correctly. BlueyeCV already publishes these dimensions in the ROS message (`p2_msgs::msg::ObjectDetections`) — this brings the protobuf definition to parity.

Backward compatible: new fields default to 0 for existing producers.
