### PR TITLE
Add SetLogFrequencyReq/Rep messages for logging frequency configuration

### DIFF
--- a/protobuf_definitions/req_rep.proto
+++ b/protobuf_definitions/req_rep.proto
@@ -169,6 +169,17 @@ message SetPubFrequencyRep {
   bool success = 1; // True if message name valid and frequency successfully updated.
 }
 
+// Request to update the logging frequency
+message SetLogFrequencyReq {
+  string message_type = 1; // Message name, f. ex. "AttitudeTel"
+  float frequency = 2; // Logging frequency (max 100 Hz).
+}
+
+// Response after updating logging frequency
+message SetLogFrequencyRep {
+  bool success = 1; // True if message name valid and frequency successfully updated.
+}
+
 // Request to get latest telemetry data
 message GetTelemetryReq {
   string message_type = 1; // Message name, f. ex. "AttitudeTel".


### PR DESCRIPTION
These new messages follow the same pattern set by `SetPubFrequencyReq/Rep`, which only modifies publish frequency but doesn't affect the logging rate. They will enable SDK users to modify the logging frequency independently from the publish frequency, for later use in post processing. 

The same guardrails will apply as normal. Duplicated messages won't be logged, and the max logging frequency would be 100 Hz.

Related to https://github.com/BluEye-Robotics/p2_drone/issues/961