### PR TITLE
feat: add RecordingCodec enum and recording bitrate fields

### DIFF
--- a/protobuf_definitions/message_formats.proto
+++ b/protobuf_definitions/message_formats.proto
@@ -860,6 +860,13 @@ enum StreamingProtocol {
   STREAMING_PROTOCOL_RTSP_MJPEG = 2; // RTSP streaming protocol using MJPEG codec. No recording when activated.
 }
 
+// Recording video codec.
+enum RecordingCodec {
+  RECORDING_CODEC_UNSPECIFIED = 0; // Use platform default (H.264).
+  RECORDING_CODEC_H264 = 1; // H.264/AVC codec. Wider compatibility with players/editors.
+  RECORDING_CODEC_H265 = 2; // H.265/HEVC codec. Better compression, limited compatibility. Ultra only.
+}
+
 // Camera parameters.
 message CameraParameters {
   reserved 19;
@@ -894,6 +901,12 @@ message CameraParameters {
   // If 0 or unset, the system will use a default of 1400.
   // The Blueye App allows users to set values between 500 and 1460.
   uint32 mtu_size = 24;
+
+  // Recording video codec. If unset, uses platform default.
+  RecordingCodec recording_codec = 25;
+  // Recording bitrate in bits/sec. If 0 or unset, a default is computed based
+  // on resolution, framerate, and encoding. Set explicitly to override.
+  int32 recording_bitrate = 26;
 }
 
 // Available temperature units.


### PR DESCRIPTION
Add support for dynamic recording bitrate and codec selection in `CameraParameters`:

- **`RecordingCodec` enum**: `UNSPECIFIED` (default H.264), `H264`, `H265` (Ultra only)
- **`recording_codec` (field 25)**: Select recording codec
- **`recording_bitrate` (field 26)**: Recording bitrate in bps (0 = auto-computed from resolution/fps/codec)

This enables:
- Dynamic bitrate scaling based on resolution and framerate (Normal quality presets computed on drone)
- App/SDK manual bitrate override for expert use
- H.265 recording on Ultra (H.264 remains default for compatibility)

Related: BluEye-Robotics/gst_rtsp_record#277