### PR TITLE
Add Blueye Scaling Laser device ID

### DIFF
--- a/protobuf_definitions/message_formats.proto
+++ b/protobuf_definitions/message_formats.proto
@@ -1028,6 +1028,7 @@ enum GuestPortDeviceID {
   GUEST_PORT_DEVICE_ID_BLUEYE_EXTERNAL_USB_STORAGE = 45; // Blueye External USB Storage.
   GUEST_PORT_DEVICE_ID_BLUEYE_MULTIBEAM_SERVO_V2 = 46; // Blueye Multibeam Skid Servo V2.
   GUEST_PORT_DEVICE_ID_CERULEAN_OMNISCAN_450_COMPACT = 47; // Cerulean Omniscan 450 Compact.
+  GUEST_PORT_DEVICE_ID_BLUEYE_SCALING_LASER = 48; // Blueye Scaling Laser.
 }
 
 // Guest port number.


### PR DESCRIPTION
This pull request adds a new device identifier to the `GuestPortDeviceID` enum in the `protobuf_definitions/message_formats.proto` file. This update allows the system to recognize and handle the Blueye Scaling Laser device.

Device support:

* Added `GUEST_PORT_DEVICE_ID_BLUEYE_SCALING_LASER` (value 48) to the `GuestPortDeviceID` enum to support the Blueye Scaling Laser device.