### PR TITLE
Convert TypeScript package to ESM

### DIFF
--- a/.github/workflows/ci-typescript.yaml
+++ b/.github/workflows/ci-typescript.yaml
@@ -45,7 +45,9 @@ jobs:
             --ts_proto_out=./out \
             --ts_proto_opt=outputIndex=true \
             --ts_proto_opt=globalThisPolyfill=true \
-            --ts_proto_opt=useExactTypes=false
+            --ts_proto_opt=useExactTypes=false \
+            --ts_proto_opt=esModuleInterop=true \
+            --ts_proto_opt=importSuffix=.js
 
       - name: Compile
         run: pnpm run build

--- a/.github/workflows/ci-typescript.yaml
+++ b/.github/workflows/ci-typescript.yaml
@@ -37,20 +37,28 @@ jobs:
           pnpm install
 
       - name: Generate
-        run: |
-          mkdir -p ./out/ &&
-          protoc protobuf_definitions/*.proto \
-            --plugin=./node_modules/.bin/protoc-gen-ts_proto \
-            --proto_path=protobuf_definitions \
-            --ts_proto_out=./out \
-            --ts_proto_opt=outputIndex=true \
-            --ts_proto_opt=globalThisPolyfill=true \
-            --ts_proto_opt=useExactTypes=false \
-            --ts_proto_opt=esModuleInterop=true \
-            --ts_proto_opt=importSuffix=.js
+        run: pnpm run generate
 
       - name: Compile
         run: pnpm run build
+
+      - name: Verify package entrypoints
+        run: |
+          SMOKE=$(mktemp -d)
+          TARBALL=$(pnpm pack --pack-destination "$SMOKE" | tail -1)
+          cd "$SMOKE"
+          npm init -y > /dev/null
+          npm install "$TARBALL" > /dev/null
+          node --input-type=module -e "
+            import { blueye } from '@blueyerobotics/protocol-definitions';
+            if (!blueye.protocol.GetBatteryReq) throw new Error('missing expected export');
+            console.log('ESM import OK');
+          "
+          node --input-type=commonjs -e "
+            const { blueye } = require('@blueyerobotics/protocol-definitions');
+            if (!blueye.protocol.GetBatteryReq) throw new Error('missing expected export');
+            console.log('CJS require OK');
+          "
 
       - name: Publish to npm
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,9 @@ bin
 obj
 out
 
+# typescript outputs
+dist
+
 # Other
 build
 build_imx

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,9 +30,11 @@ script, so keep changes in one place. `--ts_proto_opt=importSuffix=.js` is requi
 the package compiles as ESM with `moduleResolution: NodeNext`, which needs explicit
 file extensions on relative imports.
 
-The npm package is ESM-only (`"type": "module"` plus an `exports` map). The `.` entry
-uses a `default` condition rather than `import`, so `require()` still resolves on
-Node.js 22.12+ via `require(esm)`.
+The npm package ships ES modules only — `"type": "module"` plus an `exports` map,
+with no separate CommonJS build. The `.` entry uses a `default` condition rather
+than `import`, so `require()` still resolves on Node.js 22.12+ via `require(esm)`;
+an `import` condition would match ESM callers only and fail everything else with
+`ERR_PACKAGE_PATH_NOT_EXPORTED`. The `./dist/*` subpath keeps deep imports working.
 
 ### C#/.NET
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,17 +22,17 @@ cmake --install build --prefix /usr/local
 ### TypeScript
 ```
 pnpm install
-# Generate TypeScript from proto files:
-mkdir -p ./out/ && protoc protobuf_definitions/*.proto \
-  --plugin=./node_modules/.bin/protoc-gen-ts_proto \
-  --proto_path=protobuf_definitions \
-  --ts_proto_out=./out \
-  --ts_proto_opt=outputIndex=true \
-  --ts_proto_opt=globalThisPolyfill=true \
-  --ts_proto_opt=useExactTypes=false
-# Compile TypeScript:
-pnpm run build
+pnpm run generate   # generate TypeScript from proto files into ./out (requires protoc)
+pnpm run build      # compile ./out into ./dist
 ```
+The protoc flags live in the `generate` script in `package.json`; CI runs the same
+script, so keep changes in one place. `--ts_proto_opt=importSuffix=.js` is required —
+the package compiles as ESM with `moduleResolution: NodeNext`, which needs explicit
+file extensions on relative imports.
+
+The npm package is ESM-only (`"type": "module"` plus an `exports` map). The `.` entry
+uses a `default` condition rather than `import`, so `require()` still resolves on
+Node.js 22.12+ via `require(esm)`.
 
 ### C#/.NET
 ```

--- a/README.npm.md
+++ b/README.npm.md
@@ -8,6 +8,29 @@ TypeScript protobuf definitions for Blueye Robotics protocols generated using [t
 npm install @blueyerobotics/protocol-definitions
 ```
 
+## Module format
+
+This package is published as **ESM only**. `import` works natively:
+
+```ts
+import { blueye } from "@blueyerobotics/protocol-definitions";
+```
+
+CommonJS consumers can still `require()` it on Node.js 22.12+ (or 20.19+), which
+supports `require()` of ES modules:
+
+```js
+const { blueye } = require("@blueyerobotics/protocol-definitions");
+```
+
+On older Node.js versions `require()` fails with `ERR_REQUIRE_ESM` — use `import`
+or a dynamic `await import()` instead.
+
+The package root is the supported entry point. Individual generated modules stay
+reachable under `./dist/` (for example
+`@blueyerobotics/protocol-definitions/dist/telemetry.js`) if you want to import a
+single protocol file to keep bundles small.
+
 ## Usage
 
 ```ts

--- a/README.npm.md
+++ b/README.npm.md
@@ -2,6 +2,16 @@
 
 TypeScript protobuf definitions for Blueye Robotics protocols generated using [ts-proto](https://github.com/stephenh/ts-proto).
 
+## Protocol version
+
+This package implements **version 3** of the Blueye communication protocol, used by
+drones running Blunux 3.0 and newer. Older drones use the separate
+[legacy protocol](https://github.com/BluEye-Robotics/blueye.legacyprotocol).
+
+The npm version above tracks releases of *this package* — packaging, module format
+and generated API surface — and is independent of the protocol version. A major
+version bump here does not indicate a new protocol generation.
+
 ## Installation
 
 ```bash

--- a/README.npm.md
+++ b/README.npm.md
@@ -10,14 +10,15 @@ npm install @blueyerobotics/protocol-definitions
 
 ## Module format
 
-This package is published as **ESM only**. `import` works natively:
+This package ships ES modules only — there is no separate CommonJS build. Both
+`import` and `require()` work on current Node.js releases.
 
 ```ts
 import { blueye } from "@blueyerobotics/protocol-definitions";
 ```
 
-CommonJS consumers can still `require()` it on Node.js 22.12+ (or 20.19+), which
-supports `require()` of ES modules:
+`require()` is supported on Node.js 22.12+ (or 20.19+), which can load an ES
+module from CommonJS:
 
 ```js
 const { blueye } = require("@blueyerobotics/protocol-definitions");

--- a/package.json
+++ b/package.json
@@ -7,8 +7,14 @@
     "type": "git",
     "url": "https://github.com/BluEye-Robotics/ProtocolDefinitions.git"
   },
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "types": "./dist/index.d.ts",
   "files": [
     "dist"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blueyerobotics/protocol-definitions",
-  "version": "3.2.0",
+  "version": "4.0.0",
   "license": "LGPL-3.0-only",
   "description": "TypeScript definitions for Blueye Robotics protocols",
   "repository": {
@@ -11,14 +11,16 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
-    }
+      "default": "./dist/index.js"
+    },
+    "./dist/*": "./dist/*"
   },
   "types": "./dist/index.d.ts",
   "files": [
     "dist"
   ],
   "scripts": {
+    "generate": "rm -rf out && mkdir -p out && protoc protobuf_definitions/*.proto --plugin=./node_modules/.bin/protoc-gen-ts_proto --proto_path=protobuf_definitions --ts_proto_out=./out --ts_proto_opt=outputIndex=true --ts_proto_opt=globalThisPolyfill=true --ts_proto_opt=useExactTypes=false --ts_proto_opt=esModuleInterop=true --ts_proto_opt=importSuffix=.js",
     "build": "tsc"
   },
   "dependencies": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
-    "module": "CommonJS",
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "declaration": true,
     "outDir": "dist",
     "strict": true,


### PR DESCRIPTION
## Summary

Publishes `@blueyerobotics/protocol-definitions` as an ESM package, while keeping CommonJS consumers working on modern Node.

- **`tsconfig.json`**: `module`/`moduleResolution` set to `NodeNext`, `target` raised to `ES2022`. This makes TypeScript's resolution match what Node actually does at runtime.
- **`package.json`**: adds `"type": "module"` and an `exports` map; drops `main`. Version bumped to **4.0.0**.
- **Generation**: the protoc invocation moved into a `generate` npm script, with `esModuleInterop=true` and `importSuffix=.js` so ts-proto emits the explicit `.js` extensions NodeNext requires.
- **CI**: new step packs the tarball and verifies both entrypoints against the real `exports` map.

## Compatibility

The `.` entry uses a **`default`** condition rather than `import`:

```json
"exports": {
  ".": { "types": "./dist/index.d.ts", "default": "./dist/index.js" },
  "./dist/*": "./dist/*"
}
```

`import` matches ESM callers only, so `require()` would fall through the map and fail with `ERR_PACKAGE_PATH_NOT_EXPORTED`. `default` matches any loader, and Node 22.12+ / 20.19+ can `require()` an ES module (`require(esm)`) as long as the graph has no top-level await — generated protobuf code has none. Verified locally:

- `import { blueye } from "@blueyerobotics/protocol-definitions"` — works
- `require("@blueyerobotics/protocol-definitions")` — returns `['blueye', 'google']`
- CJS consumer type-checking under `module: nodenext` (TS 5.9) — clean

On Node older than 22.12, `require()` fails with `ERR_REQUIRE_ESM`.

The `./dist/*` subpath keeps deep imports working with the same specifiers as before the `exports` map existed.

## Why 4.0.0

**This does not mean protocol v4.** The package still implements protocol v3; the npm version tracks releases of this package, not the protocol generation. The two were never coupled — the NuGet package is at `5.4.0` for the same protocol v3, and the CMake project at `3.0.0`. Since the published npm README never actually stated the protocol version, this PR adds it to `README.npm.md` explicitly, which is a firmer signal than a leading digit.


CI publishes `3.2.0-<sha>` on every master push under the `latest` tag. A consumer who ran `npm install` has `^3.2.0-<sha>` in their manifest, and that caret range **does** match other `3.2.0-*` prereleases, since prerelease identifiers compare lexically. Without a major bump, `npm update` could walk a consumer onto the ESM build with no signal. `4.0.0` breaks the range and forces an explicit upgrade.

## Notes

- Nothing forced this migration — `@bufbuild/protobuf` dual-publishes, and the previous CJS build already worked for ESM consumers via `cjs-module-lexer` named-export detection. The wins here are correct NodeNext type resolution and roughly 12% smaller bundles (583.7 KB → 515.8 KB for a one-message esbuild bundle); tree-shaking is limited because ts-proto's encode/decode closures keep most of the graph reachable.
- Shipping one file rather than dual-publishing also avoids the dual package hazard, where a consumer reaching the package both ways gets two module instances with `instanceof` checks that silently fail across the boundary.
- `CLAUDE.md` documented a protoc command without the new flags, which produced `TS2835` errors on every file under the new tsconfig. Folding the flags into the `generate` script keeps CI and the docs in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
