### PR TITLE
Rename ObjectDetections to ModelDetections for multi-model support

### DIFF
--- a/protobuf_definitions/message_formats.proto
+++ b/protobuf_definitions/message_formats.proto
@@ -1438,12 +1438,13 @@ message ObjectDetection {
   uint32 tracking_id = 5; // Unique ID for tracking the same object across frames.
 }
 
-// A list of object detections from a single video frame.
-message ObjectDetections {
+// A list of object detections from a single model for a single video frame.
+message ModelDetections {
   repeated ObjectDetection detections = 1; // List of detections in the frame.
   Camera camera = 2; // Which camera the detections are from.
   uint32 image_width = 3; // Width of the source image (px).
   uint32 image_height = 4; // Height of the source image (px).
+  string model_name = 5; // Name of the computer vision model that produced the detections.
 }
 
 // Generic filter settings.

--- a/protobuf_definitions/telemetry.proto
+++ b/protobuf_definitions/telemetry.proto
@@ -322,9 +322,9 @@ message LogEntryTel {
   }
 }
 
-// Object detections from a computer vision model.
+// Object detections from all active computer vision models.
 message ObjectDetectionsTel {
-  ObjectDetections object_detections = 1; // List of object detections from a video frame.
+  repeated ModelDetections model_detections = 1; // Per-model detection results.
 }
 
 // Turbidity filter settings telemetry message.


### PR DESCRIPTION
Renames the `ObjectDetections` message to `ModelDetections` and adds a `model_name` field. Updates `ObjectDetectionsTel` to use `repeated ModelDetections` so detections from multiple CV models can be aggregated into a single telemetry message.

This enables running multiple detection models simultaneously (e.g. TinyYOLOv2 on DLA + a custom model on CUDA) and bundling their results together.