### PR TITLE
feat: add ColorCorrection protobuf messages

### DIFF
--- a/protobuf_definitions/control.proto
+++ b/protobuf_definitions/control.proto
@@ -229,8 +229,17 @@ message FormatRemovableStorageDeviceCtrl {
 }
 
 // Message sent when the user wants to set turbidity filter settings.
+// Uses CLAHE to enhance the contrast of the video, which can make it easier to see details in turbid water.
+// Only supported on X3 Ultra.
 message SetTurbidityFilterCtrl {
   FilterMessage turbidity_filter = 1; // Message with the turbidity filter settings to set.
+}
+
+// Message sent when the user wants to set auto white balance settings.
+// Removes underwater color casts using the Gray World algorithm.
+// Only supported on X3 Ultra.
+message SetAutoWhiteBalanceCtrl {
+  FilterMessage awb_filter = 1; // Message with the auto white balance settings to set.
 }
 
 // Issue a command to set the digital pan, tilt, and zoom of the main camera.

--- a/protobuf_definitions/control.proto
+++ b/protobuf_definitions/control.proto
@@ -229,8 +229,19 @@ message FormatRemovableStorageDeviceCtrl {
 }
 
 // Message sent when the user wants to set turbidity filter settings.
+// Uses CLAHE to enhance the contrast of the video, which can make it easier to see details in turbid water.
+// Only supported on X3 Ultra.
 message SetTurbidityFilterCtrl {
   FilterMessage turbidity_filter = 1; // Message with the turbidity filter settings to set.
+}
+
+// Message sent when the user wants to set color correction settings.
+// Applies depth- and scene-driven underwater color correction, restoring the
+// red/blue balance lost with depth. The intensity field scales the correction
+// (0.0 = off/identity, 1.0 = full).
+// Only supported on X3 Ultra.
+message SetColorCorrectionCtrl {
+  FilterMessage color_correction_filter = 1; // Message with the color correction settings to set.
 }
 
 // Issue a command to set the digital pan, tilt, and zoom of the main camera.

--- a/protobuf_definitions/telemetry.proto
+++ b/protobuf_definitions/telemetry.proto
@@ -334,6 +334,13 @@ message TurbidityFilterTel {
   FilterMessage turbidity_filter = 1; // Turbidity filter settings.
 }
 
+// Auto white balance settings telemetry message.
+//
+// Message is published when the filter settings are changed.
+message AutoWhiteBalanceTel {
+  FilterMessage awb_filter = 1; // Auto white balance settings.
+}
+
 // Digital pan, tilt, and zoom telemetry from the main camera.
 //
 // Reports the actual pan, tilt, and zoom state of the camera.

--- a/protobuf_definitions/telemetry.proto
+++ b/protobuf_definitions/telemetry.proto
@@ -334,6 +334,13 @@ message TurbidityFilterTel {
   FilterMessage turbidity_filter = 1; // Turbidity filter settings.
 }
 
+// Color correction settings telemetry message.
+//
+// Message is published when the filter settings are changed.
+message ColorCorrectionTel {
+  FilterMessage color_correction_filter = 1; // Color correction settings.
+}
+
 // Digital pan, tilt, and zoom telemetry from the main camera.
 //
 // Reports the actual pan, tilt, and zoom state of the camera.


### PR DESCRIPTION
Add `SetColorCorrectionCtrl` and `ColorCorrectionTel` protobuf messages for the X3 Ultra underwater color-correction filter (`beuwcolor`).

Uses the shared `FilterMessage` format (enabled + intensity, where intensity 0–1 scales the correction toward identity).

> Note: renamed from the original `AutoWhiteBalance`/Gray-World naming — the filter we're shipping is depth- and scene-driven underwater color correction, not auto white balance.

**Related PRs:**
- https://github.com/BluEye-Robotics/p2_drone/pull/965
- https://github.com/BluEye-Robotics/gst_rtsp_record/pull/299