### PR TITLE
Bump project and protobuf/grpc versions

### DIFF
--- a/Blueye.Protocol.Protobuf.csproj
+++ b/Blueye.Protocol.Protobuf.csproj
@@ -5,7 +5,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <LangVersion>13.0</LangVersion>
     <PackageId>Blueye.Protocol.Protobuf</PackageId>
-    <VersionPrefix>5.4.0</VersionPrefix>
+    <VersionPrefix>5.9.0</VersionPrefix>
     <Company>Blueye Robotics AS</Company>
     <ProduceReferenceAssembly>True</ProduceReferenceAssembly>
     <PackageDescription>Library with dotnet representation of the ProtocolDefinition protobuf files.</PackageDescription>
@@ -13,12 +13,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Protobuf" Version="3.34.1" />
-    <PackageReference Include="Google.Protobuf.Tools" Version="3.34.1">
+    <PackageReference Include="Google.Protobuf" Version="3.35.0" />
+    <PackageReference Include="Google.Protobuf.Tools" Version="3.35.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Grpc.Tools" Version="2.78.0">
+    <PackageReference Include="Grpc.Tools" Version="2.80.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
Update VersionPrefix to 5.9.0 and upgrade protobuf/grpc packages: Google.Protobuf and Google.Protobuf.Tools to 3.35.0, and Grpc.Tools to 2.80.0. These minor version bumps bring in the latest protobuf/grpc tool and runtime fixes and improvements.