### PR TITLE
Add LaserDetection message for tracked laser output

### DIFF
--- a/protobuf_definitions/message_formats.proto
+++ b/protobuf_definitions/message_formats.proto
@@ -127,6 +127,7 @@ message LaserDetection {
   float confidence = 5; // Confidence of the detection (0..1).
   uint32 image_width = 6; // Source frame width.
   uint32 image_height = 7; // Source frame height.
+  float laser_width = 8; // Real world distance between the two laser dots (m).
 }
 
 // Latitude and longitude position in WGS 84 decimal degrees format.

--- a/protobuf_definitions/message_formats.proto
+++ b/protobuf_definitions/message_formats.proto
@@ -103,6 +103,30 @@ message Lights {
 // turns the laser on.
 message Laser {
   float value = 1; // Laser intensity, any value above 0 turns the laser on (0..1).
+  bool modulated = 2; // Modulate the laser at 5Hz for tracking. Only available on Ultra.
+}
+
+// Point in 2D space.
+message Point2D {
+  float x = 1; // X coordinate of the point (px).
+  float y = 2; // Y coordinate of the point (px).
+}
+
+// Message representing the detection of scaling lasers in the main camera.
+//
+// The message contains the centroids of the detected dots, the distance between them in pixels,
+// and the confidence of the detection. The dots are detected through temporal DFT analysis of
+// 5 Hz laser modulation, isolating flickering pixels from the static scene background.
+//
+// Only available on Ultra.
+message LaserDetection {
+  bool detected = 1; // True if the laser is detected by the drone.
+  Point2D dot1 = 2; // First dot centroid (leftmost).
+  Point2D dot2 = 3; // Second dot centroid (rightmost).
+  float pixel_distance = 4; // Distance between dots in pixels.
+  float confidence = 5; // Confidence of the detection (0..1).
+  int image_width = 6; // Source frame width.
+  int image_height = 7; // Source frame height.
 }
 
 // Latitude and longitude position in WGS 84 decimal degrees format.

--- a/protobuf_definitions/message_formats.proto
+++ b/protobuf_definitions/message_formats.proto
@@ -125,8 +125,8 @@ message LaserDetection {
   Point2D dot2 = 3; // Second dot centroid (rightmost).
   float pixel_distance = 4; // Distance between dots in pixels.
   float confidence = 5; // Confidence of the detection (0..1).
-  int image_width = 6; // Source frame width.
-  int image_height = 7; // Source frame height.
+  uint32 image_width = 6; // Source frame width.
+  uint32 image_height = 7; // Source frame height.
 }
 
 // Latitude and longitude position in WGS 84 decimal degrees format.

--- a/protobuf_definitions/message_formats.proto
+++ b/protobuf_definitions/message_formats.proto
@@ -128,6 +128,8 @@ message LaserDetection {
   uint32 image_width = 6; // Source frame width.
   uint32 image_height = 7; // Source frame height.
   float laser_width = 8; // Real world distance between the two laser dots (m).
+  float corrected_pixel_distance = 9; // Distance after lens undistortion (px).
+  float estimated_distance = 10; // Estimated subject distance (m).
 }
 
 // Latitude and longitude position in WGS 84 decimal degrees format.

--- a/protobuf_definitions/telemetry.proto
+++ b/protobuf_definitions/telemetry.proto
@@ -87,6 +87,7 @@ message GuestPortLightsTel {
 // Receive the status of any lasers connected to the drone.
 message LaserTel {
   Laser laser = 1; // Laser status.
+  LaserDetection laser_detection = 2; // Detection of the laser by the computer vision pipeline. Only available on Ultra.
 }
 
 // Pilot position (originating from device GPS) for logging.

--- a/protobuf_definitions/telemetry.proto
+++ b/protobuf_definitions/telemetry.proto
@@ -87,7 +87,9 @@ message GuestPortLightsTel {
 // Receive the status of any lasers connected to the drone.
 message LaserTel {
   Laser laser = 1; // Laser status.
-  LaserDetection laser_detection = 2; // Detection of the laser by the computer vision pipeline. Only available on Ultra.
+  LaserDetection laser_detection =
+    2; // Detection of the laser by the computer vision pipeline. Only
+        // available on Ultra.
 }
 
 // Pilot position (originating from device GPS) for logging.


### PR DESCRIPTION
This pull request extends the protobuf message definitions to support new computer vision features related to laser detection, specifically for the Ultra model. It introduces new messages for representing 2D points and laser detection results, and updates telemetry to include detection data.

**Additions for laser detection and telemetry:**

* `protobuf_definitions/message_formats.proto`:
  * Added the `modulated` boolean field to the `Laser` message to indicate if the laser is modulated at 5Hz for tracking.
  * Introduced the `Point2D` message for representing 2D coordinates.
  * Added the `LaserDetection` message to encapsulate detected laser dot centroids, their pixel distance, detection confidence, and source image dimensions, supporting new computer vision features.

**Telemetry enhancements:**

* `protobuf_definitions/telemetry.proto`:
  * Updated the `LaserTel` message to include a `laser_detection` field, reporting computer vision-based laser detection status and details.