### PR TITLE
Update Google.Protobuf and Grpc.Tools versions

### DIFF
--- a/Blueye.Protocol.Protobuf.csproj
+++ b/Blueye.Protocol.Protobuf.csproj
@@ -13,12 +13,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Protobuf" Version="3.35.0" />
-    <PackageReference Include="Google.Protobuf.Tools" Version="3.35.0">
+    <PackageReference Include="Google.Protobuf" Version="3.35.1" />
+    <PackageReference Include="Google.Protobuf.Tools" Version="3.35.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Grpc.Tools" Version="2.80.0">
+    <PackageReference Include="Grpc.Tools" Version="2.80.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
Bump package versions: Google.Protobuf and Google.Protobuf.Tools from 3.35.0 to 3.35.1, and Grpc.Tools from 2.80.0 to 2.80.1. These are patch-level updates to pull in upstream fixes; project references and asset/private settings remain unchanged.