### PR TITLE
Add thermal zones and video codec engine utilization to SystemPerformanceInfo

### DIFF
--- a/protobuf_definitions/message_formats.proto
+++ b/protobuf_definitions/message_formats.proto
@@ -1412,11 +1412,18 @@ message VideoCodecInfo {
   float nvjpg_frequency_mhz = 6; // JPEG engine clock frequency (MHz).
   bool vic_active = 7; // Video Image Compositor (VIC) is active.
   float vic_frequency_mhz = 8; // VIC clock frequency (MHz).
+
   // i.MX only (CODA VPU).
   bool vpu_active = 9; // VPU clock is gated on.
   float vpu_frequency_mhz = 10; // VPU AXI clock frequency (MHz).
   uint32 vpu_codec_irq_count = 11; // Cumulative VPU_CODEC_IRQ count.
   uint32 vpu_jpg_irq_count = 12; // Cumulative VPU_JPG_IRQ count.
+
+  // Jetson only (host1x actmon engine utilization, 0..1).
+  float encoder_load = 13; // Video encoder (NVENC) utilization (0..1).
+  float decoder_load = 14; // Video decoder (NVDEC) utilization (0..1).
+  float nvjpg_load = 15; // JPEG engine (NVJPG) utilization (0..1).
+  float vic_load = 16; // Video Image Compositor (VIC) utilization (0..1).
 }
 
 // System performance information.

--- a/protobuf_definitions/message_formats.proto
+++ b/protobuf_definitions/message_formats.proto
@@ -1393,6 +1393,14 @@ enum ThermalZoneId {
   THERMAL_ZONE_ID_UNSPECIFIED = 0; // Unspecified thermal zone.
   THERMAL_ZONE_ID_TJ = 1; // Junction temperature (Tj).
   THERMAL_ZONE_ID_CANISTER = 2; // Canister temperature.
+  THERMAL_ZONE_ID_CPU = 3; // CPU thermal zone.
+  THERMAL_ZONE_ID_GPU = 4; // GPU thermal zone.
+  THERMAL_ZONE_ID_CV0 = 5; // Vision accelerator 0 thermal zone.
+  THERMAL_ZONE_ID_CV1 = 6; // Vision accelerator 1 thermal zone.
+  THERMAL_ZONE_ID_CV2 = 7; // Vision accelerator 2 thermal zone.
+  THERMAL_ZONE_ID_SOC0 = 8; // SoC 0 thermal zone.
+  THERMAL_ZONE_ID_SOC1 = 9; // SoC 1 thermal zone.
+  THERMAL_ZONE_ID_SOC2 = 10; // SoC 2 thermal zone.
 }
 
 // Thermal zone reading.


### PR DESCRIPTION
## Summary

Extends `SystemPerformanceInfo` protobuf definitions in two ways:

1. **Thermal zones** — adds the additional thermal zones exposed by the Jetson platform to `ThermalZoneId`: `CPU`, `GPU`, `CV0`-`CV2`, `SOC0`-`SOC2` (ids 3-10). Existing `UNSPECIFIED`, `TJ`, and `CANISTER` ids are preserved for wire compatibility.
2. **Video codec engine load** — adds `encoder_load`, `decoder_load`, `nvjpg_load`, and `vic_load` (0..1) to `VideoCodecInfo`, sourced from the Jetson host1x actmon counters (the same source tegrastats uses for its engine utilization percentages).

## Related PRs

This is the base of a 3-PR stack and should merge first:
- p2_msgs: mirrors these fields in the ROS message definitions
- p2_drone: populates the new fields from sysfs/debugfs

🤖 Generated with [Claude Code](https://claude.com/claude-code)