### PR TITLE
Add GP4-GP6 guest ports and per-port 24V sensing for X7

### DIFF
--- a/Blueye.Protocol.Protobuf.csproj
+++ b/Blueye.Protocol.Protobuf.csproj
@@ -5,7 +5,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <LangVersion>13.0</LangVersion>
     <PackageId>Blueye.Protocol.Protobuf</PackageId>
-    <VersionPrefix>5.9.0</VersionPrefix>
+    <VersionPrefix>6.0.0</VersionPrefix>
     <Company>Blueye Robotics AS</Company>
     <ProduceReferenceAssembly>True</ProduceReferenceAssembly>
     <PackageDescription>Library with dotnet representation of the ProtocolDefinition protobuf files.</PackageDescription>

--- a/protobuf_definitions/message_formats.proto
+++ b/protobuf_definitions/message_formats.proto
@@ -1229,7 +1229,7 @@ message GuestPortCurrent {
   double gp1_bat = 1; // Current on GP1 battery voltage (A).
   double gp2_bat = 2; // Current on GP2 battery voltage (A).
   double gp3_bat = 3; // Current on GP3 battery voltage (A).
-  double gp_24v = 4; // Current on common/input 24V supply (A).
+  double gp_24v = 4; // Current on common/input 24V supply (A). Only present on X1/X3 (not X3 Ultra or X7).
   double gp4_bat = 5; // Current on GP4 battery voltage (A).
   double gp5_bat = 6; // Current on GP5 battery voltage (A).
   double gp6_bat = 7; // Current on GP6 battery voltage (A).

--- a/protobuf_definitions/message_formats.proto
+++ b/protobuf_definitions/message_formats.proto
@@ -832,18 +832,33 @@ message ErrorFlags {
   bool gp1_read = 9; // Guest port 1 read error.
   bool gp2_read = 10; // Guest port 2 read error.
   bool gp3_read = 11; // Guest port 3 read error.
+  bool gp4_read = 48; // Guest port 4 read error.
+  bool gp5_read = 49; // Guest port 5 read error.
+  bool gp6_read = 50; // Guest port 6 read error.
   bool gp1_not_flashed = 12; // Guest port 1 not flashed.
   bool gp2_not_flashed = 13; // Guest port 2 not flashed.
   bool gp3_not_flashed = 14; // Guest port 3 not flashed.
+  bool gp4_not_flashed = 51; // Guest port 4 not flashed.
+  bool gp5_not_flashed = 52; // Guest port 5 not flashed.
+  bool gp6_not_flashed = 53; // Guest port 6 not flashed.
   bool gp1_unknown_device = 15; // Unknown device on guest port 1.
   bool gp2_unknown_device = 16; // Unknown device on guest port 2.
   bool gp3_unknown_device = 17; // Unknown device on guest port 3.
+  bool gp4_unknown_device = 54; // Unknown device on guest port 4.
+  bool gp5_unknown_device = 55; // Unknown device on guest port 5.
+  bool gp6_unknown_device = 56; // Unknown device on guest port 6.
   bool gp1_device_connection = 18; // Guest port 1 connection error.
   bool gp2_device_connection = 19; // Guest port 2 connection error.
   bool gp3_device_connection = 20; // Guest port 3 connection error.
+  bool gp4_device_connection = 57; // Guest port 4 connection error.
+  bool gp5_device_connection = 58; // Guest port 5 connection error.
+  bool gp6_device_connection = 59; // Guest port 6 connection error.
   bool gp1_device = 21; // Guest port 1 device error.
   bool gp2_device = 22; // Guest port 2 device error.
   bool gp3_device = 23; // Guest port 3 device error.
+  bool gp4_device = 60; // Guest port 4 device error.
+  bool gp5_device = 61; // Guest port 5 device error.
+  bool gp6_device = 62; // Guest port 6 device error.
   bool drone_serial_not_set = 24; // Drone serial number not set.
   bool drone_serial = 25; // Drone serial number error.
   bool mb_eeprom_read = 26; // MB eeprom read error.
@@ -859,10 +874,19 @@ message ErrorFlags {
   bool ds_serial = 36; // DS serial number error.
   bool gp_current_read = 37; // Error reading GP current.
   bool gp_current = 38; // Max GP current exceeded.
-  bool gp1_bat_current = 39; // Max battery current exceeded on GP1.
-  bool gp2_bat_current = 40; // Max battery current exceeded on GP2.
-  bool gp3_bat_current = 41; // Max battery current exceeded on GP3.
-  bool gp_20v_current = 42; // Max 20V current exceeded on GP.
+  bool gp1_bat_current = 39; // Max battery current exceeded on guest port 1.
+  bool gp2_bat_current = 40; // Max battery current exceeded on guest port 2.
+  bool gp3_bat_current = 41; // Max battery current exceeded on guest port 3.
+  bool gp4_bat_current = 63; // Max battery current exceeded on guest port 4.
+  bool gp5_bat_current = 64; // Max battery current exceeded on guest port 5.
+  bool gp6_bat_current = 65; // Max battery current exceeded on guest port 6.
+  bool gp_24v_current = 42; // Max 24V current exceeded on GP.
+  bool gp1_24v_current = 66; // Max 24V current exceeded on guest port 1.
+  bool gp2_24v_current = 67; // Max 24V current exceeded on guest port 2.
+  bool gp3_24v_current = 68; // Max 24V current exceeded on guest port 3.
+  bool gp4_24v_current = 69; // Max 24V current exceeded on guest port 4.
+  bool gp5_24v_current = 70; // Max 24V current exceeded on guest port 5.
+  bool gp6_24v_current = 71; // Max 24V current exceeded on guest port 6.
   bool dvl_thermal_protection_mode = 43; // DVL is in thermal protection mode.
   bool dvl_no_power = 44; // GP protection has been triggered at boot or faulty DVL.
   bool usb_disconnect = 45; // USB disconnect.
@@ -1082,6 +1106,9 @@ enum GuestPortNumber {
   GUEST_PORT_NUMBER_PORT_1 = 1; // Guest port 1.
   GUEST_PORT_NUMBER_PORT_2 = 2; // Guest port 2.
   GUEST_PORT_NUMBER_PORT_3 = 3; // Guest port 3.
+  GUEST_PORT_NUMBER_PORT_4 = 4; // Guest port 4.
+  GUEST_PORT_NUMBER_PORT_5 = 5; // Guest port 5.
+  GUEST_PORT_NUMBER_PORT_6 = 6; // Guest port 6.
 }
 
 // List of navigation sensors that can be used by the position observer.
@@ -1156,6 +1183,9 @@ message GuestPortInfo {
   GuestPortConnectorInfo gp1 = 1; // Information about guest port 1.
   GuestPortConnectorInfo gp2 = 2; // Information about guest port 2.
   GuestPortConnectorInfo gp3 = 3; // Information about guest port 3.
+  GuestPortConnectorInfo gp4 = 4; // Information about guest port 4.
+  GuestPortConnectorInfo gp5 = 5; // Information about guest port 5.
+  GuestPortConnectorInfo gp6 = 6; // Information about guest port 6.
 }
 
 // GuestPort restart information.
@@ -1193,7 +1223,16 @@ message GuestPortCurrent {
   double gp1_bat = 1; // Current on GP1 battery voltage (A).
   double gp2_bat = 2; // Current on GP2 battery voltage (A).
   double gp3_bat = 3; // Current on GP3 battery voltage (A).
-  double gp_20v = 4; // Current on common 20V supply (A).
+  double gp_24v = 4; // Current on common/input 24V supply (A).
+  double gp4_bat = 5; // Current on GP4 battery voltage (A).
+  double gp5_bat = 6; // Current on GP5 battery voltage (A).
+  double gp6_bat = 7; // Current on GP6 battery voltage (A).
+  double gp1_24v = 8; // Current on GP1 24V supply (A).
+  double gp2_24v = 9; // Current on GP2 24V supply (A).
+  double gp3_24v = 10; // Current on GP3 24V supply (A).
+  double gp4_24v = 11; // Current on GP4 24V supply (A).
+  double gp5_24v = 12; // Current on GP5 24V supply (A).
+  double gp6_24v = 13; // Current on GP6 24V supply (A).
 }
 
 // Vector with 3 elements.

--- a/protobuf_definitions/message_formats.proto
+++ b/protobuf_definitions/message_formats.proto
@@ -887,6 +887,12 @@ message ErrorFlags {
   bool gp4_24v_current = 69; // Max 24V current exceeded on guest port 4.
   bool gp5_24v_current = 70; // Max 24V current exceeded on guest port 5.
   bool gp6_24v_current = 71; // Max 24V current exceeded on guest port 6.
+  bool gp1_5v_current = 72; // Max 5V current exceeded on guest port 1.
+  bool gp2_5v_current = 73; // Max 5V current exceeded on guest port 2.
+  bool gp3_5v_current = 74; // Max 5V current exceeded on guest port 3.
+  bool gp4_5v_current = 75; // Max 5V current exceeded on guest port 4.
+  bool gp5_5v_current = 76; // Max 5V current exceeded on guest port 5.
+  bool gp6_5v_current = 77; // Max 5V current exceeded on guest port 6.
   bool dvl_thermal_protection_mode = 43; // DVL is in thermal protection mode.
   bool dvl_no_power = 44; // GP protection has been triggered at boot or faulty DVL.
   bool usb_disconnect = 45; // USB disconnect.
@@ -1233,6 +1239,12 @@ message GuestPortCurrent {
   double gp4_24v = 11; // Current on GP4 24V supply (A).
   double gp5_24v = 12; // Current on GP5 24V supply (A).
   double gp6_24v = 13; // Current on GP6 24V supply (A).
+  double gp1_5v = 14; // Current on GP1 5V supply (A).
+  double gp2_5v = 15; // Current on GP2 5V supply (A).
+  double gp3_5v = 16; // Current on GP3 5V supply (A).
+  double gp4_5v = 17; // Current on GP4 5V supply (A).
+  double gp5_5v = 18; // Current on GP5 5V supply (A).
+  double gp6_5v = 19; // Current on GP6 5V supply (A).
 }
 
 // Vector with 3 elements.

--- a/protobuf_definitions/message_formats.proto
+++ b/protobuf_definitions/message_formats.proto
@@ -880,7 +880,7 @@ message ErrorFlags {
   bool gp4_bat_current = 63; // Max battery current exceeded on guest port 4.
   bool gp5_bat_current = 64; // Max battery current exceeded on guest port 5.
   bool gp6_bat_current = 65; // Max battery current exceeded on guest port 6.
-  bool gp_24v_current = 42; // Max 24V current exceeded on GP.
+  bool gp_24v_current = 42; // Max 24V current exceeded on GP. Only present on X1/X3 (not X3 Ultra or X7).
   bool gp1_24v_current = 66; // Max 24V current exceeded on guest port 1.
   bool gp2_24v_current = 67; // Max 24V current exceeded on guest port 2.
   bool gp3_24v_current = 68; // Max 24V current exceeded on guest port 3.


### PR DESCRIPTION
## Summary

As part of **X7**, the platform will have 6 guest ports (up from 3). This PR extends the guest port definitions to GP4–GP6 in `protobuf_definitions/message_formats.proto`, adds per-port 24V and 5V current sensing for all six ports, and renames the 20V fields to 24V.

| Location | Change |
|---|---|
| `GuestPortNumber` enum | Added `GUEST_PORT_NUMBER_PORT_4..6` (values 4–6) |
| `GuestPortInfo` | Added `gp4..gp6` (fields 4–6) |
| `GuestPortCurrent` | Added `gp4_bat..gp6_bat` (fields 5–7), per-port `gp1_24v..gp6_24v` (fields 8–13), and per-port `gp1_5v..gp6_5v` (fields 14–19) |
| `ErrorFlags` | Added per-port flags for GP4–GP6 (`read`, `not_flashed`, `unknown_device`, `device_connection`, `device`, `bat_current`), per-port `gp1_24v_current..gp6_24v_current`, and per-port `gp1_5v_current..gp6_5v_current` — new field numbers **48–77** |
| `Blueye.Protocol.Protobuf.csproj` | Version bump `5.9.0 → 6.0.0` |

## Current sensing

X7 adds per-port 24V and 5V current sensing to all six guest ports:
- `GuestPortCurrent` gains `gp1_24v`–`gp6_24v` (fields 8–13) and `gp1_5v`–`gp6_5v` (fields 14–19). The existing common-supply field is **kept for backwards compatibility** (field 4) and is now documented as the common/input 24V supply.
- `ErrorFlags` gains per-port `gp1_24v_current`–`gp6_24v_current` (fields 66–71) and `gp1_5v_current`–`gp6_5v_current` (fields 72–77), alongside the existing common `gp_24v_current`.

## Naming: 20V → 24V

The guest-port supply is 24V, so the `20V` fields are renamed: `gp_20v → gp_24v`, `gp_20v_current → gp_24v_current`. **Field numbers and types are unchanged**, so the wire format stays compatible — only the generated symbol names change (a source-level breaking change for consumers, intentional). This follows the review discussion concluding on 24V.

## ErrorFlags ordering

The new per-port flags are grouped so that `gp1..gp6` of each error type are listed together (e.g. all `*_read`, then all `*_not_flashed`, …). The existing GP1–GP3 flags keep their original field numbers (9–41) for wire compatibility; the new flags use 48–77, assigned so they read in ascending order down the file. As a result `gp_24v_current` (field 42) now appears later in source than `gp6_bat_current` (65) — proto does not require numeric source order.

## Design notes

- **Wire compatibility preserved.** No existing field number changed; only field *names* (20V→24V) and source ordering were modified.
- **Comment consistency.** All per-port `bat_current` / `24v_current` / `5v_current` comments use the "guest port N" full-name form, matching the other per-port flags (this also corrected the pre-existing GP1–GP3 lines).

## Validation

- `protolint` passes
- `protoc` compiles cleanly
- ErrorFlags field numbers verified unique and contiguous (1–77); GuestPortCurrent (1–19)

## Downstream note

The generated consumer libraries (C++ / Python / TS / C#) and firmware will need to handle the new fields and the 20V→24V renames, but those live outside this repo. Tracked for `libguestport` in BluEye-Robotics/libguestport#371.

🤖 Generated with [Claude Code](https://claude.com/claude-code)