### PR TITLE
Add dual-battery telemetry and drone PowerSource

### DIFF
--- a/protobuf_definitions/message_formats.proto
+++ b/protobuf_definitions/message_formats.proto
@@ -783,6 +783,17 @@ enum PressureSensorType {
   PRESSURE_SENSOR_TYPE_MS5637_02BA03 = 4; // The internal pressure sensor using the MS5637 02BA03 pressure sensor.
 }
 
+// How the drone is powered.
+//
+// Lets clients determine the power configuration (e.g. parallel batteries on the
+// X7) directly from DroneInfo, without waiting for telemetry. May be extended in
+// the future, e.g. with topside power.
+enum PowerSource {
+  POWER_SOURCE_UNSPECIFIED = 0; // Power source unknown / not determined.
+  POWER_SOURCE_SINGLE_BATTERY = 1; // A single battery.
+  POWER_SOURCE_PARALLEL_BATTERIES = 2; // Two batteries running in parallel (e.g. X7).
+}
+
 // Information about the drone.
 //
 // Information about a loaded computer vision model.
@@ -816,6 +827,7 @@ message DroneInfo {
   GuestPortInfo gp = 9; // Guest port information.
   PressureSensorType depth_sensor = 11; // Type of depth sensor that is connected to the drone.
   repeated CvModelInfo cv_models = 12; // List of loaded computer vision models.
+  PowerSource power_source = 13; // How the drone is powered.
 }
 
 // Known error states for the drone.

--- a/protobuf_definitions/telemetry.proto
+++ b/protobuf_definitions/telemetry.proto
@@ -108,14 +108,24 @@ message TimeLapseStateTel {
 }
 
 // Receive essential information about the battery status.
+//
+// On models with two batteries running in parallel (e.g. the X7), second_battery
+// holds the essential information for the second battery. When only a single
+// battery is used, second_battery is undefined (not set).
 message BatteryTel {
   Battery battery = 1; // Essential battery information.
+  Battery second_battery = 2; // Second battery, when present. Not set if only one battery is used.
 }
 
 // Receive detailed information about a battery using the
 // BQ40Z50 battery management system.
+//
+// On models with two batteries running in parallel (e.g. the X7), second_battery
+// holds the detailed information for the second battery. When only a single
+// battery is used, second_battery is undefined (not set).
 message BatteryBQ40Z50Tel {
   BatteryBQ40Z50 battery = 1; // Detailed battery information.
+  BatteryBQ40Z50 second_battery = 2; // Second battery, when present. Not set if only one battery is used.
 }
 
 // Receive the dive time of the drone.


### PR DESCRIPTION
## Summary

Prepares the protocol for **X7** configurations that can run **two batteries in parallel**, and lets clients learn the drone's power configuration up front (without waiting for telemetry).

| Location | Change |
|---|---|
| `BatteryTel` (`telemetry.proto`) | Added `Battery second_battery = 2` for the second parallel battery |
| `BatteryBQ40Z50Tel` (`telemetry.proto`) | Added `BatteryBQ40Z50 second_battery = 2` for the second parallel battery |
| `PowerSource` enum (`message_formats.proto`) | **New enum**: `UNSPECIFIED` / `SINGLE_BATTERY` / `PARALLEL_BATTERIES` |
| `DroneInfo` (`message_formats.proto`) | Added `PowerSource power_source = 13` |

## Second battery

`second_battery` reuses the existing types (`Battery` / `BatteryBQ40Z50`) so the second battery reports the same information as the first. It has message presence in proto3, so on single-battery drones it is simply **left unset** — documented on both messages.

```proto
message BatteryTel {
  Battery battery = 1; // Essential battery information.
  Battery second_battery = 2; // Second battery, when present. Not set if only one battery is used.
}
```

## PowerSource enum

```proto
enum PowerSource {
  POWER_SOURCE_UNSPECIFIED = 0; // Power source unknown / not determined.
  POWER_SOURCE_SINGLE_BATTERY = 1; // A single battery.
  POWER_SOURCE_PARALLEL_BATTERIES = 2; // Two batteries running in parallel (e.g. X7).
}
```

Exposed via `DroneInfo.power_source` (field 13) so clients can determine the power configuration (parallel batteries on the X7) directly from `DroneInfo`. The enum is intentionally extensible — e.g. a future `POWER_SOURCE_TOPSIDE` for topside power.

- Zero value is named `POWER_SOURCE_UNSPECIFIED` to follow the repo's enum convention (and proto3 best practice); its comment documents the "unknown / not determined" meaning.

## Validation

- `protolint` passes
- `protoc` compiles cleanly
- `DroneInfo` field numbers verified unique/contiguous (1–13)

## Notes

- No existing fields changed → wire-compatible.
- No package version bump included in this PR (let me know if one is wanted for publishing).
- Downstream consumer libraries / firmware will need regenerated bindings to use the new fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)