### PR TITLE
Fix gen-docs CI: run protoc-gen-doc on host instead of stale container

### DIFF
--- a/.github/workflows/gen-docs.yaml
+++ b/.github/workflows/gen-docs.yaml
@@ -8,21 +8,18 @@ on:
 jobs:
   generate-documentation:
     runs-on: ubuntu-latest
-    container:
-      image: pseudomuto/protoc-gen-doc:1.5.1
     steps:
       - name: Checkout source
         uses: actions/checkout@v4
-      - name: Print path
-        run: echo "${{ github.workspace }}/protobuf_definitions"
-      - name: Create output configDirectory
+      - name: Install protoc + protoc-gen-doc
+        run: |
+          sudo apt-get update && sudo apt-get install -y protobuf-compiler
+          go install github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc@v1.5.1
+          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
+      - name: Create output directory
         run: mkdir -p docs
-      - name: List files
-        run: ls -la
       - name: Generate documentation
         run: protoc --doc_out=docs --doc_opt=html,protocol.html --proto_path=protobuf_definitions protobuf_definitions/*.proto
-      - name: List doc files
-        run: ls -la docs
       - name: Publish artifacts
         uses: fixpoint/azblob-upload-artifact@v4
         with:


### PR DESCRIPTION
Fixes #271

## Problem

The `Generate documentation` workflow fails on every push to `master`, at the **Checkout source** step — before any docs are generated. It runs inside `container: pseudomuto/protoc-gen-doc:1.5.1`, whose ~4-year-old Alpine/musl base can no longer host the Node binary GitHub injects to run JS actions (`actions/checkout`). With Node 20 being deprecated, the runner now injects Node 24, which needs `pthread_getname_np` (musl ≥ 1.2.3):

```
Error relocating /__e/node24_alpine/bin/node: pthread_getname_np: symbol not found
```

Bumping `actions/checkout` doesn't help — the failing binary is the runtime the runner injects, not the action's code.

## Fix (Option 1 from the issue)

Drop the container and install the toolchain directly on `ubuntu-latest`:

- `protoc` via apt (`protobuf-compiler`)
- `protoc-gen-doc` via `go install …@v1.5.1` (Go is preinstalled on runners)
- add `$(go env GOPATH)/bin` to `$GITHUB_PATH` so `protoc` finds the plugin

**`protoc-gen-doc` is pinned to v1.5.1** — the same version as the old container — so the generated HTML is identical. The doc-generation command, triggers, secrets, and Azure upload (`container: protocoldefinitions`, artifact `docs`) are unchanged.

Also removed the leftover debug steps (`Print path`, `List files`, `List doc files`).

## Why not the alternatives

- **Buf migration (Option 2):** best long-term, but a real migration (adds `buf.yaml`/`buf.gen.yaml`) — out of scope for a CI hotfix.
- **Community rebuilt image (Option 3):** trades one stale dependency for a less-trusted one.
- **`ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION` stopgap:** Node 20 is on a removal path; only buys time.

## Validation

- Workflow YAML parses cleanly.
- Full verification is the workflow run itself (it only triggers on push to `master`), so it will be exercised once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)