### PR TITLE
Add in-dive annotation messages

### DIFF
--- a/protobuf_definitions/control.proto
+++ b/protobuf_definitions/control.proto
@@ -261,3 +261,13 @@ message SetSotTargetCtrl {
 // Issue a command to clear the single-object tracking (SOT) target (stop tracking).
 message ClearSotTargetCtrl {
 }
+
+// Request to add an annotation to the current dive.
+//
+// Sent by the app when a diver picks a type from the in-dive command palette.
+// The drone stamps the authoritative time, publishes the result as an
+// AnnotationTel to every connected client, and writes it to the dive logfile, so
+// all clients converge on the same set. Fire-and-forget, like LightsCtrl.
+message AnnotationCtrl {
+  Annotation annotation = 1; // The annotation to record. The drone owns the timestamp, not this message.
+}

--- a/protobuf_definitions/message_formats.proto
+++ b/protobuf_definitions/message_formats.proto
@@ -1654,7 +1654,7 @@ message Annotation {
   string title = 2; // Optional short title; cloud falls back to the type name if empty. Max 200 chars.
   string body = 3; // Optional free-form note. Unbounded.
   google.protobuf.Duration duration = 4; // Optional span; omit for a point-in-time marker.
-  AnnotationSource source = 5; // Where the annotation originated.
+  AnnotationSource source = 5; // Origin of the annotation; the app sets APP, the drone sets DRONE for its own.
 }
 
 // A snapshot of an organisation's annotation-type catalogue.

--- a/protobuf_definitions/message_formats.proto
+++ b/protobuf_definitions/message_formats.proto
@@ -1630,40 +1630,24 @@ enum AnnotationSource {
   ANNOTATION_SOURCE_DRONE = 3; // Emitted by the drone itself.
 }
 
-// A user-defined annotation type from a Blueye Cloud organisation's catalogue.
-//
-// The organisation maintains a catalogue of these in Blueye Cloud. It is synced
-// to the app, pushed to the drone, and embedded in the dive logfile. The cloud
-// is the authority on the documented length limits.
-message AnnotationType {
-  string slug = 1; // Stable per-org id, lower-case, unique, max 50 chars (e.g. "hazard").
-  string name = 2; // Title shown in the palette, max 50 chars (e.g. "Hazard").
-  string icon = 3; // Font Awesome solid icon name, kebab-case, no prefix (e.g. "triangle-exclamation").
-  string color = 4; // RGB hex including the leading '#', always 7 chars (e.g. "#DC2626").
-  int32 sort_order = 5; // Palette sort position, ascending, 0-based.
-  string id = 6; // Optional cloud UUID (RFC 4122). Informational; prefer slug. Empty if app-local.
-}
-
 // A single annotation added during a dive, e.g. by a diver tapping a type in the
 // app command palette, or emitted by the drone itself.
+//
+// Self-contained: it carries the type's display fields (name/icon/color) inline,
+// so the drone, any connected client, and the dive logfile can render it without
+// a separate catalogue. The app keeps the full catalogue locally (synced from
+// Blueye Cloud) to drive its palette, but only complete annotations go over the
+// wire. type_slug lets Blueye Cloud correlate the annotation to its type on import.
 //
 // The drone owns the timestamp: when this is logged the enclosing BinlogRecord
 // carries the time, like any other sample, so there is no time field here.
 message Annotation {
-  string type_slug = 1; // Slug of the chosen AnnotationType. Empty for a free-form annotation.
-  string title = 2; // Optional short title; cloud falls back to the type name if empty. Max 200 chars.
-  string body = 3; // Optional free-form note. Unbounded.
-  google.protobuf.Duration duration = 4; // Optional span; omit for a point-in-time marker.
-  AnnotationSource source = 5; // Origin of the annotation; the app sets APP, the drone sets DRONE for its own.
-}
-
-// A snapshot of an organisation's annotation-type catalogue.
-//
-// The drone logs one near the start of the dive so every Annotation.type_slug in
-// the logfile resolves to a name/icon/color even if the type is later renamed or
-// deleted in Blueye Cloud.
-message AnnotationCatalog {
-  string organisation_slug = 1; // Org the catalogue belongs to (e.g. "blueye-robotics").
-  repeated AnnotationType types = 2; // Available annotation types, ordered by sort_order.
-  google.protobuf.Timestamp synced_at = 3; // When the catalogue was fetched from cloud (UTC).
+  string type_slug = 1; // Stable type id for grouping / Cloud correlation. Empty for a free-form annotation.
+  string type_name = 2; // Type display name, e.g. "Hazard". Snapshot of the type at creation time.
+  string type_icon = 3; // Font Awesome solid icon name, kebab-case (e.g. "triangle-exclamation").
+  string type_color = 4; // Type colour, RGB hex incl. leading '#', 7 chars (e.g. "#DC2626").
+  string title = 5; // Optional annotation title; cloud falls back to type_name if empty. Max 200 chars.
+  string body = 6; // Optional free-form note. Unbounded.
+  google.protobuf.Duration duration = 7; // Optional span; omit for a point-in-time marker.
+  AnnotationSource source = 8; // Origin of the annotation; the app sets APP, the drone sets DRONE for its own.
 }

--- a/protobuf_definitions/message_formats.proto
+++ b/protobuf_definitions/message_formats.proto
@@ -1621,3 +1621,49 @@ message SotState {
   uint32 image_width = 3; // Width of the source frame in pixels.
   uint32 image_height = 4; // Height of the source frame in pixels.
 }
+
+// Origin of an annotation. Mirrors the AnnotationSource enum in Blueye Cloud.
+enum AnnotationSource {
+  ANNOTATION_SOURCE_UNSPECIFIED = 0; // Origin not specified.
+  ANNOTATION_SOURCE_CLOUD = 1; // Created in Blueye Cloud after the dive.
+  ANNOTATION_SOURCE_APP = 2; // Created in the app during the dive.
+  ANNOTATION_SOURCE_DRONE = 3; // Emitted by the drone itself.
+}
+
+// A user-defined annotation type from a Blueye Cloud organisation's catalogue.
+//
+// The organisation maintains a catalogue of these in Blueye Cloud. It is synced
+// to the app, pushed to the drone, and embedded in the dive logfile. The cloud
+// is the authority on the documented length limits.
+message AnnotationType {
+  string slug = 1; // Stable per-org id, lower-case, unique, max 50 chars (e.g. "hazard").
+  string name = 2; // Title shown in the palette, max 50 chars (e.g. "Hazard").
+  string icon = 3; // Font Awesome solid icon name, kebab-case, no prefix (e.g. "triangle-exclamation").
+  string color = 4; // RGB hex including the leading '#', always 7 chars (e.g. "#DC2626").
+  int32 sort_order = 5; // Palette sort position, ascending, 0-based.
+  string id = 6; // Optional cloud UUID (RFC 4122). Informational; prefer slug. Empty if app-local.
+}
+
+// A single annotation added during a dive, e.g. by a diver tapping a type in the
+// app command palette, or emitted by the drone itself.
+//
+// The drone owns the timestamp: when this is logged the enclosing BinlogRecord
+// carries the time, like any other sample, so there is no time field here.
+message Annotation {
+  string type_slug = 1; // Slug of the chosen AnnotationType. Empty for a free-form annotation.
+  string title = 2; // Optional short title; cloud falls back to the type name if empty. Max 200 chars.
+  string body = 3; // Optional free-form note. Unbounded.
+  google.protobuf.Duration duration = 4; // Optional span; omit for a point-in-time marker.
+  AnnotationSource source = 5; // Where the annotation originated.
+}
+
+// A snapshot of an organisation's annotation-type catalogue.
+//
+// The drone logs one near the start of the dive so every Annotation.type_slug in
+// the logfile resolves to a name/icon/color even if the type is later renamed or
+// deleted in Blueye Cloud.
+message AnnotationCatalog {
+  string organisation_slug = 1; // Org the catalogue belongs to (e.g. "blueye-robotics").
+  repeated AnnotationType types = 2; // Available annotation types, ordered by sort_order.
+  google.protobuf.Timestamp synced_at = 3; // When the catalogue was fetched from cloud (UTC).
+}

--- a/protobuf_definitions/message_formats.proto
+++ b/protobuf_definitions/message_formats.proto
@@ -1635,7 +1635,7 @@ enum AnnotationSource {
 //
 // Self-contained: it carries the type's display fields (name/icon/color) inline,
 // so the drone, any connected client, and the dive logfile can render it without
-// a separate catalogue. The app keeps the full catalogue locally (synced from
+// a separate catalog. The app keeps the full catalog locally (synced from
 // Blueye Cloud) to drive its palette, but only complete annotations go over the
 // wire. type_slug lets Blueye Cloud correlate the annotation to its type on import.
 //
@@ -1645,8 +1645,8 @@ message Annotation {
   string type_slug = 1; // Stable type id for grouping / Cloud correlation. Empty for a free-form annotation.
   string type_name = 2; // Type display name, e.g. "Hazard". Snapshot of the type at creation time.
   string type_icon = 3; // Font Awesome solid icon name, kebab-case (e.g. "triangle-exclamation").
-  string type_color = 4; // Type colour, RGB hex incl. leading '#', 7 chars (e.g. "#DC2626").
-  string title = 5; // Optional annotation title; cloud falls back to type_name if empty. Max 200 chars.
+  string type_color = 4; // Type color, RGB hex incl. leading '#', 7 chars (e.g. "#DC2626").
+  string title = 5; // Optional annotation title; Cloud falls back to type_name if empty. Max 200 chars.
   string body = 6; // Optional free-form note. Unbounded.
   google.protobuf.Duration duration = 7; // Optional span; omit for a point-in-time marker.
   AnnotationSource source = 8; // Origin of the annotation; the app sets APP, the drone sets DRONE for its own.

--- a/protobuf_definitions/req_rep.proto
+++ b/protobuf_definitions/req_rep.proto
@@ -246,3 +246,17 @@ message GetLogStreamingStatusReq {
 message GetLogStreamingStatusRep {
   bool enabled = 1; // If log streaming is enabled or disabled.
 }
+
+// Set (replace) the annotation-type catalogue on the drone.
+//
+// Pushed by the app after it syncs the organisation's catalogue from Blueye
+// Cloud. The drone keeps it for the session, publishes it as an
+// AnnotationCatalogTel, and logs a snapshot so the dive logfile is
+// self-describing. Mirrors SetMissionReq/SetMissionRep.
+message SetAnnotationCatalogReq {
+  AnnotationCatalog catalog = 1; // The full catalogue. Replaces any previously set catalogue.
+}
+
+// Response after setting the annotation catalogue.
+message SetAnnotationCatalogRep {
+}

--- a/protobuf_definitions/req_rep.proto
+++ b/protobuf_definitions/req_rep.proto
@@ -246,17 +246,3 @@ message GetLogStreamingStatusReq {
 message GetLogStreamingStatusRep {
   bool enabled = 1; // If log streaming is enabled or disabled.
 }
-
-// Set (replace) the annotation-type catalogue on the drone.
-//
-// Pushed by the app after it syncs the organisation's catalogue from Blueye
-// Cloud. The drone keeps it for the session, publishes it as an
-// AnnotationCatalogTel, and logs a snapshot so the dive logfile is
-// self-describing. Mirrors SetMissionReq/SetMissionRep.
-message SetAnnotationCatalogReq {
-  AnnotationCatalog catalog = 1; // The full catalogue. Replaces any previously set catalogue.
-}
-
-// Response after setting the annotation catalogue.
-message SetAnnotationCatalogRep {
-}

--- a/protobuf_definitions/telemetry.proto
+++ b/protobuf_definitions/telemetry.proto
@@ -365,10 +365,11 @@ message SotStateTel {
 
 // An annotation that now exists on the dive.
 //
-// Either added by a client (the drone echoes its AnnotationCtrl here) or emitted
-// by the drone itself; Annotation.source distinguishes the two. Published to
-// every connected client and written to the dive logfile. A late-joining client
-// can fetch the most recent one with GetTelemetryReq("AnnotationTel").
+// Either added by a client (the drone echoes its AnnotationCtrl here, source APP)
+// or emitted by the drone itself (source DRONE); CLOUD is the post-dive Blueye
+// Cloud path and is not seen here. Published to every connected client and
+// written to the dive logfile. A late-joining client can fetch the most recent
+// one with GetTelemetryReq("AnnotationTel").
 message AnnotationTel {
   Annotation annotation = 1; // The annotation that was added.
 }

--- a/protobuf_definitions/telemetry.proto
+++ b/protobuf_definitions/telemetry.proto
@@ -373,12 +373,3 @@ message SotStateTel {
 message AnnotationTel {
   Annotation annotation = 1; // The annotation that was added.
 }
-
-// The annotation-type catalogue currently active on the drone.
-//
-// Published when a client sets it with SetAnnotationCatalogReq and written to the
-// dive logfile. A late-joining client fetches it with
-// GetTelemetryReq("AnnotationCatalogTel") so it can render annotation icons.
-message AnnotationCatalogTel {
-  AnnotationCatalog catalog = 1; // The active catalogue.
-}

--- a/protobuf_definitions/telemetry.proto
+++ b/protobuf_definitions/telemetry.proto
@@ -362,3 +362,22 @@ message CameraPanTiltZoomTel {
 message SotStateTel {
   SotState sot_state = 1; // Current SOT state and bounding box.
 }
+
+// An annotation that now exists on the dive.
+//
+// Either added by a client (the drone echoes its AnnotationCtrl here) or emitted
+// by the drone itself; Annotation.source distinguishes the two. Published to
+// every connected client and written to the dive logfile. A late-joining client
+// can fetch the most recent one with GetTelemetryReq("AnnotationTel").
+message AnnotationTel {
+  Annotation annotation = 1; // The annotation that was added.
+}
+
+// The annotation-type catalogue currently active on the drone.
+//
+// Published when a client sets it with SetAnnotationCatalogReq and written to the
+// dive logfile. A late-joining client fetches it with
+// GetTelemetryReq("AnnotationCatalogTel") so it can render annotation icons.
+message AnnotationCatalogTel {
+  AnnotationCatalog catalog = 1; // The active catalogue.
+}


### PR DESCRIPTION
## Summary

Adds the protocol for **in-dive annotations**: during a dive a diver (or any connected client) taps an annotation type in the app's command palette, and the annotation is broadcast to every connected client and recorded into the dive logfile. Part of the Blueye Cloud in-dive annotations feature.

Annotations are **self-contained** — each one carries the type's display fields (`type_name`, `type_icon`, `type_color`) inline, so the drone, connected clients, and the dive logfile can render it with no separate catalogue. The app keeps the full annotation-type catalogue locally (synced from Blueye Cloud) to drive its palette; only complete annotations go over the wire. `type_slug` is kept so Blueye Cloud can correlate the annotation back to its type on import.

> Note: an earlier revision of this PR pushed/embedded an `AnnotationCatalog` to the drone. That was simplified away in favour of self-contained annotations (see commit history) — it removes the catalogue-sync messages and the "push catalogue before the dive" ordering dependency.

## Messages

**`message_formats.proto`**
- `AnnotationSource` enum — `CLOUD` / `APP` / `DRONE`.
- `Annotation` — a self-contained annotation: `type_slug`, `type_name`, `type_icon`, `type_color`, `title`, `body`, `duration`, `source`.

**`control.proto` — app → drone (request)**
- `AnnotationCtrl` — request to add an annotation. Fire-and-forget, like `LightsCtrl`.

**`telemetry.proto` — drone → all clients (authoritative, broadcast, logged)**
- `AnnotationTel` — the annotation that now exists on the dive. The drone echoes a client's `AnnotationCtrl` here to every connected client (so clients converge), can also originate one itself (`source = DRONE`), and writes it to the logfile.

## Design notes

- **Self-contained annotations** — display fields are inline, so any client / the `.bez` / downstream tooling can render an annotation without a second lookup; a late joiner's `GetTelemetryReq("AnnotationTel")` returns something fully renderable. Captures point-in-time appearance, so renaming a type in Cloud later doesn't retro-mutate old dives.
- **`type_slug` for correlation** — kept so Blueye Cloud links the annotation to its `AnnotationType` row on import (grouping, "show all Hazards"); empty for a free-form annotation.
- **Authoritative state comes up, not down** — the app renders from the `AnnotationTel` it gets back, not from its own `Ctrl`, so multiple connected clients converge (client 1 adds → client 2 sees it).
- **No timestamp on `Annotation`** — the enclosing `BinlogRecord` carries the time, like every other logged sample.
- **`source` is an informational provenance hint, not a security claim** — intentionally not enforced (first-party, non-adversarial protocol); the app sets `APP`, the drone sets `DRONE`. See review thread replies.
- **Additive & backward-compatible**, no new imports.

## Open question for review

`AnnotationTel` is a **discrete event**, not periodic state. This telemetry plane is built around publish/log *frequency* (`SetPubFrequencyReq` / `SetLogFrequencyReq`, in Hz). Please confirm the bus can publish/log it **on-change, once per event** — i.e. every annotation is delivered to subscribers and written to the logfile, with no rate-based sampling that could merge two quick annotations or drop one.

## Validation

- `protoc` compiles all protos together (syntax + cross-refs resolve). ✓
- No lines > 120 chars (protolint `max_line_length`). ✓
- `VersionPrefix` intentionally **not** bumped — the protocol version tracks the BlueyeApp version and is bumped together with the app.

## Not in this PR

- App UI (command palette, FontAwesome icon rendering — the FA7 Pro lookup is already in BlueyeApp).
- Blueye Cloud `.bez` parser that reconstructs annotation rows from `AnnotationTel` records (correlating by `type_slug`, falling back to the inlined display fields for free-form annotations).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
