### PR TITLE
Trigger protocol bump in blueye-ts after npm publish

### DIFF
--- a/.github/workflows/ci-typescript.yaml
+++ b/.github/workflows/ci-typescript.yaml
@@ -57,3 +57,12 @@ jobs:
           SHORT_SHA=${GITHUB_SHA::8}
           pnpm version --no-git-tag-version "${VERSION}-${SHORT_SHA}"
           pnpm publish --no-git-checks --access public --tag latest
+          echo "PROTOCOL_VERSION=${VERSION}-${SHORT_SHA}" >> "$GITHUB_ENV"
+
+      - name: Trigger protocol bump in blueye-ts
+        env:
+          GH_TOKEN: ${{ secrets.BLUEYE_PROTOCOL_BUMP_PAT }}
+        run: |
+          gh api repos/BluEye-Robotics/blueye-ts/dispatches \
+            -f event_type=protocol-update \
+            -f "client_payload[version]=${PROTOCOL_VERSION}"


### PR DESCRIPTION
## Summary

After publishing `@blueyerobotics/protocol-definitions` to npm, the TypeScript CI now sends a `repository_dispatch: protocol-update` event to blueye-ts carrying the published `<version>-<shortsha>`, using the `BLUEYE_PROTOCOL_BUMP_PAT` org secret. The receiving workflow (companion PR: BluEye-Robotics/blueye-ts — "Add workflow to auto-bump protocol-definitions") bumps the dependency, runs the test suite as a gate, and tags/releases a new blueye-ts version.

## Test plan

- Merge the blueye-ts companion PR first so the receiver exists on `main`.
- Merging this PR publishes a new protocol version and exercises the chain end-to-end — verify a "Protocol Bump" run appears in blueye-ts Actions and results in a bump commit, tag, release, and npm publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)