### PR TITLE
Add a gigabit Ethernet capability

### DIFF
--- a/protobuf_definitions/message_formats.proto
+++ b/protobuf_definitions/message_formats.proto
@@ -1150,6 +1150,7 @@ enum GuestPortCapability {
   GUEST_PORT_CAPABILITY_RS485 = 4; // RS485 serial.
   GUEST_PORT_CAPABILITY_USB2 = 5; // USB 2.0.
   GUEST_PORT_CAPABILITY_PWM = 6; // PWM.
+  GUEST_PORT_CAPABILITY_ETHERNET_1G = 7; // Gigabit Ethernet.
 }
 
 // List of navigation sensors that can be used by the position observer.


### PR DESCRIPTION
Adds `GUEST_PORT_CAPABILITY_ETHERNET_1G = 7`.

The X7 wires its three user ports for gigabit Ethernet and the remaining three for 100 megabit. Nothing in the catalogue needs gigabit today, but a future peripheral may, and a port that has it should be able to say so.

## How it fits the model

Capabilities are independent statements about a port, and compatibility is a plain subset test. This adds nothing to that: a gigabit port speaks 100 megabit as well, so it lists Ethernet and gigabit both, and the two entries are simply two true things about it — no implication a consumer has to know about, and no ordering in the model.

The practical consequence is that nothing changes for anything that exists. All twenty Ethernet peripherals go on requiring `ETHERNET` and go on fitting every port that has it, at either speed. A peripheral that genuinely needs the bandwidth would require `ETHERNET_1G` and resolve to the three ports that offer it.

Ports are given the same treatment in BluEye-Robotics/libguestport#386, which also carries a correction: GP4 has 100 megabit Ethernet, which the port table had recorded as none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)