### PR TITLE
Add attitude, temperature and pressure to MultibeamPing

### DIFF
--- a/protobuf_definitions/message_formats.proto
+++ b/protobuf_definitions/message_formats.proto
@@ -1317,6 +1317,11 @@ message MultibeamPing {
   bytes ping_data = 10; // Ping data (row major, 2D, grayscale image).
   GuestPortDeviceID device_id = 11; // Device ID of the sonar.
   google.protobuf.Timestamp frame_generation_timestamp = 12; // Timestamp when the frame was generated.
+  double heading = 13; // Heading (°).
+  double pitch = 14; // Pitch (°).
+  double roll = 15; // Roll (°).
+  double temperature = 16; // External temperature (°C).
+  double pressure = 17; // External pressure (bar).
 }
 
 


### PR DESCRIPTION
## Summary
- Add `heading`, `pitch`, `roll` (°), `temperature` (°C) and `pressure` (bar) fields (13–17) to `MultibeamPing`.
- The Oculus sonar reports these values in every ping (`OculusSimplePingResult`), but they were never carried into the protocol, so they never reached subscribers or the `.mbez` dive log.

Companion PR: BluEye-Robotics/libguestport (populates the fields from the Oculus driver).

## Test plan
- Cross-compiled for i.MX (`cross-imx-update`): protoc accepts the new fields and `libblueyeprotocol` builds and installs cleanly.
- libguestport builds against the updated schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)