### PR TITLE
Bump dotnet package to 6.2.0 and update protobuf dependencies

### DIFF
--- a/Blueye.Protocol.Protobuf.csproj
+++ b/Blueye.Protocol.Protobuf.csproj
@@ -5,7 +5,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <LangVersion>13.0</LangVersion>
     <PackageId>Blueye.Protocol.Protobuf</PackageId>
-    <VersionPrefix>6.0.0</VersionPrefix>
+    <VersionPrefix>6.2.0</VersionPrefix>
     <Company>Blueye Robotics AS</Company>
     <ProduceReferenceAssembly>True</ProduceReferenceAssembly>
     <PackageDescription>Library with dotnet representation of the ProtocolDefinition protobuf files.</PackageDescription>
@@ -13,12 +13,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Protobuf" Version="3.35.1" />
-    <PackageReference Include="Google.Protobuf.Tools" Version="3.35.1">
+    <PackageReference Include="Google.Protobuf" Version="3.36.0" />
+    <PackageReference Include="Google.Protobuf.Tools" Version="3.36.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Grpc.Tools" Version="2.80.1">
+    <PackageReference Include="Grpc.Tools" Version="2.83.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
Bumps the NuGet package version and refreshes the protobuf toolchain dependencies.

## Changes
- `VersionPrefix`: 6.0.0 → 6.2.0
- `Google.Protobuf`: 3.35.1 → 3.36.0
- `Google.Protobuf.Tools`: 3.35.1 → 3.36.0
- `Grpc.Tools`: 2.80.1 → 2.83.0

## Verification
`dotnet pack Blueye.Protocol.Protobuf.csproj -c Release -o out` succeeds and produces `Blueye.Protocol.Protobuf.6.2.0.nupkg`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DYJrtikP5yzFifaL2U3izA